### PR TITLE
i3: config: Added border around windows.

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -9,7 +9,8 @@
 ###---Basic Definitions---###
 #Needed for i3-gaps
 hide_edge_borders both
-for_window [class="^.*"] border pixel 0 
+new_window 1pixel
+smart_borders on
 gaps inner 15
 gaps outer 15
 font pango:hack 9


### PR DESCRIPTION
Hi! This change is related to one of your yt videos [i3 Rice Additions: ffmpeg Screencasting, ...](https://youtu.be/Ja-DgvGPDu8?t=1m11s)
i3-gaps indeed does not work correctly with window title bars, pixel-style borders work fine though (example: https://i.imgur.com/Pvu2jBc.png).
From [i3-gaps github](https://github.com/Airblader/i3): "... disable them via for_window [class="^.*"] border pixel 0 in your config. You can also use any non-zero value as long as you only use pixel-style borders."
I hope this helps. Cheers!