### PR TITLE
Stopping duplicated binding warning on NeoMutt

### DIFF
--- a/.config/mutt/gmailrc
+++ b/.config/mutt/gmailrc
@@ -19,6 +19,7 @@ set ssl_force_tls = yes
 
 mailboxes +INBOX
 
+bind index g noop
 macro index gi "<change-folder>=INBOX<enter>" "Go to inbox"
 macro index ga "<change-folder>=[Gmail].All Mail<enter>" "Go to all mail"
 macro index gs "<change-folder>=[Gmail].Sent Mail<enter>" "Go to sent mail"


### PR DESCRIPTION
Hi Luke, I used your dotfiles to get a starting point configuring Mutt, thx. I'm sending back this pull request with a minor change that would prevent a warning for those basing their config on the file on the gmailrc file.
cheers