### PR TITLE
Update shortcuts on i3 restart

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -35,7 +35,7 @@ exec --no-startup-id sudo mount -a
 #Composite manager:
 #exec --no-startup-id compton --xrender-sync-fence
 #Refresh bash/ranger shortcuts:
-exec --no-startup-id python ~/.config/Scripts/shortcuts.py
+exec_always --no-startup-id python ~/.config/Scripts/shortcuts.py
 #Try to load VGA screen if available:
 exec --no-startup-id ~/.config/Scripts/screen.sh v
 #Launch Polybar where appropriate:


### PR DESCRIPTION
Right now, the shortcut script doesn't run when reloading i3. By changing **exec** to **exec_always** the script runs when reloading i3.