### PR TITLE
fix Past duration too large

### DIFF
--- a/.config/Scripts/screencast_pulse.sh
+++ b/.config/Scripts/screencast_pulse.sh
@@ -14,9 +14,11 @@ filename="$HOME/screencast$n.mkv"
 
 ffmpeg -y \
 -f x11grab \
+-framerate 60 \
 -s $(xdpyinfo | grep dimensions | awk '{print $2;}') \
 -i :0.0 \
 -f alsa -i default \
+-r 30 \
  -c:v libx264 -r 30 -c:a flac $filename
  #-c:v ffvhuff -r 30 -c:a flac $filename
  #-f pulse -ac 1 -ar 44100 -i default \


### PR DESCRIPTION
May I recommend adding these.

I suppose a better implementation such as getting the refresh rate of the desktop and such. I also drop frames in the encoding so the file isn't huge and has less overhead.