### PR TITLE
Create rofi config that doesn't rely on .Xdefaults

### DIFF
--- a/.config/rofi/config
+++ b/.config/rofi/config
@@ -1,0 +1,12 @@
+rofi.color-enabled:     true
+rofi.color-window:      #000, #000, #000
+rofi.color-normal:      #111, #819396, #222, #008ed4, #ffffff
+rofi.color-active:      #002b37, #008ed4, #003643, #008ed4, #66c6ff
+rofi.color-urgent:      #002b37, #da4281, #003643, #008ed4, #890661
+ 
+rofi.fake-transparency: true
+rofi.lines:             3
+rofi.bw:                0
+rofi.opacity:           "10"
+rofi.hide-scrollbar:    true
+rofi.width:             30


### PR DESCRIPTION
I already tried it on fresh installations of Arch, Artix, and Void. The three of them doesn't use the rofi configs from .Xdefaults.
(And don't worry about "Merge pull request #1 from LukeSmithxyz/master", its just me having no idea on using Git}