### PR TITLE
Added location variable on i3weather script

### DIFF
--- a/.scripts/i3weather
+++ b/.scripts/i3weather
@@ -4,7 +4,11 @@
 
 ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3` >/dev/null || exit
 
-curl wttr.in > ~/.weatherreport
+### This is only if your location isn't automatically detected, otherwise you can leave it blank.
+loc=""
+location=${loc// /+}
+
+curl wttr.in/~$location > ~/.weatherreport
 
 echo -n ☔ $(cat ~/.weatherreport | sed -n 16p | sed -e 's/[^m]*m//g' | grep -o "[0-9]*%" | sort -n | sed -e '$!d')
 


### PR DESCRIPTION
As I tried this script, I got -3-0C, which is weird, and I looked at ~/.weatherreport and got this:
```
We were unable to find your location
so we have brought you to Oymyakon,
one of the coldest permanently inhabited locales on the planet.
```
It isn't able to detect my location.

My fix requires the user to manually put their location, in which it gets suffixed to the wttr.in link. If it is left blank, (which is by default) it will still use a detected location if there's one.

I can't think of a good automated patch for it, but I'll just put this as a warning just in case others might encounter the same problem and tries to modify i3weather too.

(edited the comment because I suck on constructing sentences)