### PR TITLE
Update compton.conf

### DIFF
--- a/.config/compton.conf
+++ b/.config/compton.conf
@@ -3,7 +3,7 @@ backend = "xrender"
 paint-on-overlay = true;
 glx-no-stencil = true;
 glx-no-rebind-pixmap = true;
-vsync = "opengl-swc";
+vsync = "drm";
 
 # These are important. The first one enables the opengl backend. The last one is the vsync method. Depending on the driver you might need to use a different method.
 # The other options are smaller performance tweaks that work well in most cases.


### PR DESCRIPTION
`opengl-swc` is not a valid vsync option for "xrender", thus it defaults to no vsync and screentearing oftenly occurs. `drm` would work on almost any graphics card (https://github.com/chjj/compton/wiki/vsync-guide)

This also means you can re-enable back the shadows, etc. I didn't changed it though since I'm not sure if you disabled it due to a problem or you just personally don't want the shadow.