### PR TITLE
Quote filename to allow extracting files with spaces

### DIFF
--- a/.scripts/extract
+++ b/.scripts/extract
@@ -4,25 +4,25 @@
 #       this creates a new directory in the directory where the compressed file is and dumps the content in it
 # for the second way, comment the two lines under the if and place just one '.' in front of the /$1
 #       this just dumps the content of the compressed file in the same directory of the compressed file 
-if [ -f $1 ] ; then
+if [ -f "$1" ] ; then
         NAME=${1%.*}
-        mkdir $NAME && cd $NAME
-        case $1 in
-          *.tar.bz2) tar xvjf ../$1 ;;
-          *.tar.gz) tar xvzf ../$1 ;;
-          *.tar.xz) tar xvJf ../$1 ;;
-          *.lzma) unlzma ../$1 ;;
-          *.bz2) bunzip2 ../$1 ;;
-          *.rar) unrar x -ad ../$1 ;;
-          *.gz) gunzip ../$1 ;;
-          *.tar) tar xvf ../$1 ;;
-          *.tbz2) tar xvjf ../$1 ;;
-          *.tgz) tar xvzf ../$1 ;;
-          *.zip) unzip ../$1 ;;
-          *.Z) uncompress ../$1 ;;
-          *.7z) 7z x ../$1 ;;
-          *.xz) unxz ../$1 ;;
-          *.exe) cabextract ../$1 ;;
+        mkdir "$NAME" && cd "$NAME"
+        case "$1" in          
+          *.tar.bz2) tar xvjf ../"$1" ;;
+          *.tar.gz) tar xvzf ../"$1" ;;
+          *.tar.xz) tar xvJf ../"$1" ;;
+          *.lzma) unlzma ../"$1" ;;
+          *.bz2) bunzip2 ../"$1" ;;
+          *.rar) unrar x -ad ../"$1" ;;
+          *.gz) gunzip ../"$1" ;;
+          *.tar) tar xvf ../"$1" ;;
+          *.tbz2) tar xvjf ../"$1" ;;
+          *.tgz) tar xvzf ../"$1" ;;
+          *.zip) unzip ../"$1" ;;
+          *.Z) uncompress ../"$1" ;;
+          *.7z) 7z x ../"$1" ;;
+          *.xz) unxz ../"$1" ;;
+          *.exe) cabextract ../"$1" ;;
           *) echo "extract: '$1' - unknown archive method" ;;
         esac
 else


### PR DESCRIPTION
This is a fix to #45 where extract won't work if the filename of the compressed file has spaces.