### PR TITLE
Update URxvt URL launcher to use linkhandler

### DIFF
--- a/.Xdefaults
+++ b/.Xdefaults
@@ -41,7 +41,7 @@ URxvt.perl-ext-common:	default,matcher,resize-font,url-select,keyboard-select
 URxvt.colorUL:		#4682B4
 !! url-select
 URxvt.keysym.M-u:	perl:url-select:select_next
-URxvt.url-select.launcher: webview
+URxvt.url-select.launcher: linkhandler
 URxvt.url-select.underline: true
 !! keyboard-select:
 URxvt.keysym.M-Escape: perl:keyboard-select:activate
@@ -49,7 +49,7 @@ URxvt.keysym.M-Escape: perl:keyboard-select:activate
 URxvt.resize-font.smaller:	C-Down
 URxvt.resize-font.bigger:	C-Up
 !! Matcher
-URxvt.url-launcher:	webview
+URxvt.url-launcher:	linkhandler
 URxvt.matcher.button:	1
 
 rofi.color-enabled:	true


### PR DESCRIPTION
I know you're not using URxvt anymore so I think you might haven't noticed this bug. URL launching doesn't work, so I implied you just mistyped it and subtituded it with `urlview`, but it doesn't work either.
If you still remember, does this worked before? And why is it `webview` despite the program being urlview? 