### PR TITLE
Change "news" alias to newsboat

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -17,7 +17,7 @@ fi
 alias music="ncmpcpp"
 alias clock="ncmpcpp -s clock"
 alias visualizer="ncmpcpp -s visualizer"
-alias news="newsbeuter"
+alias news="newsboat"
 alias email="neomutt"
 alias files="ranger"
 alias chat="weechat"


### PR DESCRIPTION
newsbeuter is already abandoned.
Additionally, [https://github.com/LukeSmithxyz/LARBS/blob/master/src/progs.csv#L44](LARBS) installs newsboat, this might be perhaps since I launch newsboat through `$mod+n` so nobody have realized about it.