### PR TITLE
Fix i3weather blank location bug

### DIFF
--- a/.scripts/i3weather
+++ b/.scripts/i3weather
@@ -10,7 +10,7 @@ if [[ "$location" != "" ]]
     then
     location="~${location// /+}"
 fi
-curl wttr.in/$location > ~/.weatherreport
+curl -s wttr.in/$location > ~/.weatherreport
 
 echo -n ☔ $(cat ~/.weatherreport | sed -n 16p | sed -e 's/[^m]*m//g' | grep -o "[0-9]*%" | sort -n | sed -e '$!d')
 

--- a/.scripts/i3weather
+++ b/.scripts/i3weather
@@ -1,14 +1,16 @@
 #!/bin/bash
+### This is only if your location isn't automatically detected, otherwise you can leave it blank.
+location=""
 
 [[ $BLOCK_BUTTON = "1" ]] && st -e w3m wttr.in
 
 ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3` >/dev/null || exit
 
-### This is only if your location isn't automatically detected, otherwise you can leave it blank.
-loc=""
-location=${loc// /+}
-
-curl wttr.in/~$location > ~/.weatherreport
+if [[ "$location" != "" ]]
+    then
+    location="~${location// /+}"
+fi
+curl wttr.in/$location > ~/.weatherreport
 
 echo -n ☔ $(cat ~/.weatherreport | sed -n 16p | sed -e 's/[^m]*m//g' | grep -o "[0-9]*%" | sort -n | sed -e '$!d')
 


### PR DESCRIPTION
When the `loc` variable is empty, it actually curls to wttr.in/~ and the website thinks you inputted a blank location, instead of automatically detecting your location (as of going to wttr.in/ without a location input)

I was the same user who pulled that request and haven't realized that it shouldn't have the tilde when it's empty.
I was retarded.