### PR TITLE
Update for multihead systems

### DIFF
--- a/.config/i3/lock.sh
+++ b/.config/i3/lock.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
+#!/bin/bash
 
 # Approximate timeout rate in milliseconds (checked every 5 seconds).
 timeout="10000"
 
-# Take a screenshot:
-scrot /tmp/screen.png
+# Take a screenshot of every screen available:
+xdpyinfo -ext XINERAMA | sed '/^  head #/!d;s///' |
+{
+  while IFS=' :x@,' read i w h x y; do
+    INDEX=$i
+    import -window root -crop ${w}x$h+$x+$y /tmp/head_$i.png
+  done
 
-# Add the lock to the swirled and blurred image:
-[[ -f ~/.config/i3/lock.png ]] && convert /tmp/screen.png -paint 1 -swirl 360  ~/.config/i3/lock.png -gravity center -composite -matte /tmp/screen.png
+# Add the lock to the swirled and blurred images:
+  for i in `seq 0 ${INDEX}`;
+    do
+      convert /tmp/head_${i}.png -paint 1 -swirl 360 ~/.config/i3/lock.png -gravity center -composite -matte /tmp/head_${i}.png;
+    done
+}
+
+#Combine all screen images into one big image
+convert +append /tmp/head_*.png /tmp/screen.png
 
 # Pause music (mocp and mpd):
 mocp -P
@@ -18,6 +31,6 @@ i3lock -e -f -c 000000 -i /tmp/screen.png
 
 # If still locked after $timeout milliseconds, turn off screen.
 while [[ $(pgrep -x i3lock) ]]; do
-	[[ $timeout -lt $(xssstate -i) ]] && xset dpms force off
-	sleep 5
+  [[ $timeout -lt $(xssstate -i) ]] && xset dpms force off
+  sleep 5
 done


### PR DESCRIPTION
As I use two displays, this script causes an undesirable effect, the padlock image is positioned in the middle of the screens while the green unlock thing is positioned on the center of each screen.

This update takes one separate screenshot per display connected, apply all the effects, merge the padlock image and stich them in order to have one padlock image per screen.

I'm taking the screenshots via imagemagick's import instead of scrot.

As this can be useful to someone else, i'm opening this pull request.

Sorry for my English, It's not my primary language.
