### PR TITLE
Remove annoying i3wm mouse behavior

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -26,6 +26,8 @@ set $shutdown sudo shutdown -h now
 set $reboot sudo reboot
 set $netrefresh --no-startup-id sudo systemctl restart NetworkManager
 set $hibernate sudo systemctl suspend
+focus_follows_mouse no
+mouse_warping none
 
 # #---Starting External Scripts---# #
 # Setting the background:


### PR DESCRIPTION
This is purely a personal preference of mine. If this is an undesirable change, then we can easily revert back to the old behavior we had before by making this change instead:

```
focus_follows_mouse yes
mouse_warping none
```

I was actually hoping for one of these change or the other - FWIW, I believe making things explicit and obvious to the user like this is a great practice. It is not up for me to decide what the default mouse behavior of LARBS should be moving forward, but I also think that there is absolutely no harm in explicitly defining these options in the i3wm config file.