### PR TITLE
 tpb: start transmission-daemon if it is not running 

### DIFF
--- a/.scripts/tpb
+++ b/.scripts/tpb
@@ -11,6 +11,7 @@
 # you can add -- at the end to indicate end of options
 # (if your program supports it, most do)
 program='/usr/bin/transmission-remote -a'
+daemon='transmission-daemon'
 TPB="https://thepiratebay.org"
 
 # show N first matches by default
@@ -140,22 +141,26 @@ if [ -z "$down" ] ; then
 	exit 0
 fi
 
-# download all torrents in list
+# starts daemon if it was not already running and download all torrents in list
 echo -n "Downloading torrent(s): "
-for torrent in $down ; do
-	# check if ID is valid and in range of results, download torrent
-	if [ $torrent -ge 1 ] ; then
-		if [ $torrent -le $limit ] ; then
-			echo -n "$torrent "
-			command="$program `echo "$r" | awk -F '|' 'NR=='$torrent'{print $2; exit}'`"
-			status=$(eval "$command" 2>&1)
-			if [ $? -ne 0 ] ; then
-				echo -n '(failed!) '
-				report="$report\n(#$torrent) $status"
+if ! [ "$(pidof $daemon)" ]; then
+	$daemon
+	for torrent in $down ; do
+		# check if ID is valid and in range of results, download torrent
+		if [ $torrent -ge 1 ] ; then
+			if [ $torrent -le $limit ] ; then
+				echo -n "$torrent "
+				command="$program `echo "$r" | awk -F '|' 'NR=='$torrent'{print $2; exit}'`"
+				status=$(eval "$command" 2>&1)
+				if [ $? -ne 0 ] ; then
+					echo -n '(failed!) '
+					report="$report\n(#$torrent) $status"
+				fi
 			fi
 		fi
-	fi
-done
+	done
+fi
+
 echo
 if [ -n "$report" ] ; then
 	echo -n "Exited with errors:"


### PR DESCRIPTION
I often forget starting the transmission-daemon when I download something via the 'tpb' script. Now the daemon is started if it was not running already.