### PR TITLE
Reposition ping and add failsafe tail

### DIFF
--- a/.scripts/i3weather
+++ b/.scripts/i3weather
@@ -6,9 +6,9 @@ location=""
 
 [ "$BLOCK_BUTTON" = "1" ] && $TERMINAL -e popweather
 
-curl -s wttr.in/$location > ~/.weatherreport
+ping -q -w 1 -c 1 "$(ip r | grep default | tail -1 | cut -d ' ' -f 3)" >/dev/null || exit
 
-ping -q -w 1 -c 1 "$(ip r | grep default | cut -d ' ' -f 3)" >/dev/null || exit
+curl -s wttr.in/$location > ~/.weatherreport
 
 printf "%s" "$(sed '16q;d' ~/.weatherreport | grep -wo "[0-9]*%" | sort -n | sed -e '$!d' | sed -e "s/^/☔ /g" | tr -d '\n')"
 


### PR DESCRIPTION
The connectivity check via ping is not working properly on configurations where there are multiple gateways - e.g. when using an VPN. In my case the VPN gateway(s) are not pingable, so I added `tail -1` to get the last gateway, which should be the non-VPN one <sup>I hope, cause it is like that for me.</sup>.

I also moved the `ping` before the `curl` as checking for the connection when only parsing is left seems little too suspicious :innocent: .