### PR TITLE
dunst

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -33,8 +33,6 @@ set $hibernate sudo -A systemctl suspend
 # #---Starting External Scripts---# #
 # Setting the background and colorscheme:
 exec_always --no-startup-id wal -i ~/.config/wall.png
-# Starts dunst for notifications:
-exec --no-startup-id dunst
 # Torrent daemon:
 #exec --no-startup-id transmission-daemon
 # Composite manager:


### PR DESCRIPTION
i was looking at dunst and seems like is not necessary to execute manually 

https://wiki.archlinux.org/index.php/Dunst 
'There is no need to start or enable dunst; it is called by systemd when programs send notifications through dbus.'