### PR TITLE
Changed pamixer to pulsemixer

### DIFF
--- a/.scripts/i3volume
+++ b/.scripts/i3volume
@@ -2,11 +2,11 @@
 
 case $BLOCK_BUTTON in
 	1) $TERMINAL -e pulsemixer & disown ;;
-	3) pamixer -t ;;
-	4) pamixer -i 5 ;;
-	5) pamixer -d 5 ;;
+	3) pulsemixer --toggle-mute ;;
+	4) pulsemixer --change-volume +5 ;;
+	5) pulsemixer --change-volume -5 ;;
 esac
 
-printpastatus() { [[ $(pamixer --get-mute) = "true" ]] && echo -n 🔇 && exit
-echo 🔊 $(pamixer --get-volume)% ;}
+printpastatus() { [[ $(pulsemixer --get-mute) = 1 ]] && echo -n 🔇 "   " && exit
+echo 🔊 $(pulsemixer --get-volume | sed -e "s/\s[0-9][0-9]*//g")% ;}
 printpastatus

--- a/.scripts/lmc
+++ b/.scripts/lmc
@@ -6,10 +6,10 @@ newvol="pkill -RTMIN+10 i3blocks"
 # Uncomment if i3mpdupdate isn't running:
 
 case "$1" in
-	"up") pamixer --allow-boost -i "$2" ; $newvol ;;
-	"down") pamixer --allow-boost -d "$2" ; $newvol ;;
-	"mute") pamixer --allow-boost -t ; $newvol ;;
-	"truemute") pamixer --allow-boost -m ; $newvol ;;
+	"up") pulsemixer --change-volume +"$2" ; $newvol ;;
+	"down") pulsemixer --change-volume -"$2" ; $newvol ;;
+	"mute") pulsemixer --toggle-mute ; $newvol ;;
+	"truemute") pulsemixer --mute ; $newvol ;;
 	"toggle") mpc toggle ;;
 	"pause") mpc pause ; pauseallmpv ;;
 	"forward") mpc seek +"$2" ;;


### PR DESCRIPTION
Looks like pamixer was what was used prior to switching to pulsemixer. Since pulsemixer is used elsewhere (i.e. in i3), I figured may as well be consistent and avoid having pamixer as a dependency.