### PR TITLE
Fixed wifi blocklet coloring

### DIFF
--- a/.scripts/i3wifi
+++ b/.scripts/i3wifi
@@ -8,18 +8,18 @@ INTERFACE="${BLOCK_INSTANCE:-wlan0}"
 
 [[ "$(cat /sys/class/net/$INTERFACE/operstate)" = 'down' ]] && echo 📡 && exit
 
-QUALITY=$(grep $INTERFACE /proc/net/wireless | awk '{ print int($3 * 100 / 70) }')
+QUALITY=$(grep $INTERFACE /proc/net/wireless | awk '{ print int($3 * 100 / 70 - 1) }')
 
 echo 📶 $QUALITY%
 echo 📶 $QUALITY%
 
 # color
 if [[ $QUALITY -ge 80 ]]; then
-    echo "#00FF00"
-elif [[ $QUALITY -lt 80 ]]; then
-    echo "#FFF600"
-elif [[ $QUALITY -lt 60 ]]; then
-    echo "#FFAE00"
+	echo "#00FF00"
 elif [[ $QUALITY -lt 40 ]]; then
-    echo "#FF0000"
+	echo "#FF0000"
+elif [[ $QUALITY -lt 60 ]]; then
+	echo "#FF8000"
+elif [[ $QUALITY -lt 80 ]]; then
+	echo "#FFF600"
 fi


### PR DESCRIPTION
- With the `if-elif` structure I was getting either green or yellow since `-lt 80` gobbled up all the cases thereafter (e.g. 37 is less than 80 so the second case statement would execute)
- When signal was going up to 100% I would get a sort of dithering of my whole i3bar when it switches to and from 99%