### PR TITLE
Run programs without extensions

### DIFF
--- a/.scripts/compiler
+++ b/.scripts/compiler
@@ -1,20 +1,27 @@
 #!/bin/sh
 
 # This script will compile or run another finishing operation on a document. I
-# have this script run via vim.
+# have this script run via vim/emacs.
 #
 # tex files: Compiles to pdf, including bibliography if necessary
 # md files: Compiles to pdf via pandoc
 # rmd files: Compiles via R Markdown
+# c files: Compiles via whatever compiler is set to cc. Usually gcc. 
+# py files: runs via python command
+# go files: compiles and runs with "go run"
 # config.h files: (For suckless utils) recompiles and installs program.
 # all others: run `sent` to show a presentation
+
 
 oridir=$(pwd)
 
 file=$(readlink -f "$1")
 dir=$(dirname "$file")
 base="${file%.*}"
-cd "$dir" || exit
+shebang=$(sed -n 1p $file)
+
+cd $dir
+
 
 textype() { \
 	command="pdflatex"
@@ -26,11 +33,27 @@ textype() { \
 	$command --output-directory="$dir" "$base"
 	}
 
+shebangtest() {
+	case "$shebang" in
+		\#\!*) "$file" ;;
+		*) sent "$file" 2>/dev/null & ;;
+	esac
+}
+
+
 case "$file" in
-	*\.rmd) echo "require(rmarkdown); render('$file')" | R --vanilla ;;
+	*\.rmd) echo "require(rmarkdown); render('$file')" | R --vanilla && mv "$base".pdf "$dir"/pdfs;;
 	*\.tex) textype "$file" ;;
 	*\.md) pandoc "$file" --pdf-engine=xelatex -o "$base".pdf ;;
 	*config.h) make && sudo make install ;;
-	*) sent "$file" 2>/dev/null & ;;
+        *\.c) cc "$file" -o "$base" && "$base" ;;
+	*\.py) python "$file" ;;
+	*\.go) go run "$file" ;;
+
+
+
+	*) shebangtest ;;
+
 esac
-cd "$oridir" || exit
+cd $oridir
+


### PR DESCRIPTION
This change gives the ability to run an executable file without an extension. It just replaces your sent bit with a function called shebangtest which will test for a shebang in the first line of the file. If no shebang, then it just runs sent. I also added a few more extensions to the extension list.