### PR TITLE
replace the copy-to-clipboard hack

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -37,5 +37,4 @@ macro v set browser "setsid nohup mpv"; open-in-browser ; set browser linkhandle
 macro w set browser "w3m"; open-in-browser ; set browser linkhandler
 macro p set browser "dmenuhandler"; open-in-browser ; set browser linkhandler
 # c copies the link to the clipboard.
-# The line below is probably the skiddiest line I've ever written.
-macro c set browser "copy(){ echo $1 | xclip ;}; copy "; open-in-browser ; set browser linkhandler
+macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkandler


### PR DESCRIPTION
This is obviously the correct way to do it with xclip as well. I used xsel as xclip doesn't seem to play ball with my clipboard, so if xsel isn't pulled in as a dependency either add it or use xclip instead.