### PR TITLE
Partition labels within dmenumount prompt

### DIFF
--- a/.scripts/dmenumount
+++ b/.scripts/dmenumount
@@ -16,7 +16,7 @@ getmount() { \
 	}
 
 mountusb() { \
-	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $1}')"
+	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $2}')"
 	sudo -A mount "$chosen" && exit 0
 	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
 	sudo -A mount "$chosen" "$mp" && pgrep -x dunst && notify-send "$chosen mounted to $mp."
@@ -37,7 +37,7 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint" | awk '$2=="part"&&$4==""{printf "%s (%s)\n",$1,$3}')"
+usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part"&&$4==""{printf "[%s] %s (%s)\n",$5,$1,$3}')"
 
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit

--- a/.scripts/dmenumount
+++ b/.scripts/dmenumount
@@ -16,7 +16,7 @@ getmount() { \
 	}
 
 mountusb() { \
-	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $2}')"
+	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk -F'[ ]' '{print $2}')"
 	sudo -A mount "$chosen" && exit 0
 	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
 	sudo -A mount "$chosen" "$mp" && pgrep -x dunst && notify-send "$chosen mounted to $mp."
@@ -37,7 +37,7 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part" && $4=="" {str=($5=="") ? sprintf("%s (%s)\n",$1,$3) : sprintf("[%s] %s (%s)\n",$5,$1,$3); printf("%s",str)}')"
+usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part" && $4=="" printf("%s %s (%s)\n",$5,$1,$3)}')"
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit
 	echo "Android device(s) detected."

--- a/.scripts/dmenumount
+++ b/.scripts/dmenumount
@@ -18,7 +18,7 @@ getmount() { \
 mountusb() { \
 	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $2}')"
 	sudo -A mount "$chosen" && exit 0
-	getmount "/mnt /media /mount -maxdepth 3 -type d"
+	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
 	sudo -A mount "$chosen" "$mp" && pgrep -x dunst && notify-send "$chosen mounted to $mp."
 	}
 

--- a/.scripts/dmenumount
+++ b/.scripts/dmenumount
@@ -18,7 +18,7 @@ getmount() { \
 mountusb() { \
 	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $2}')"
 	sudo -A mount "$chosen" && exit 0
-	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
+	getmount "/mnt /media /mount -maxdepth 3 -type d"
 	sudo -A mount "$chosen" "$mp" && pgrep -x dunst && notify-send "$chosen mounted to $mp."
 	}
 
@@ -37,8 +37,7 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part"&&$4==""{printf "[%s] %s (%s)\n",$5,$1,$3}')"
-
+usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part" && $4=="" {str=($5=="") ? sprintf("%s (%s)\n",$1,$3) : sprintf("[%s] %s (%s)\n",$5,$1,$3); printf("%s",str)}')"
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit
 	echo "Android device(s) detected."

--- a/.scripts/dmenumount
+++ b/.scripts/dmenumount
@@ -37,7 +37,7 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part" && $4=="" printf("%s %s (%s)\n",$5,$1,$3)}')"
+usbdrives="$(lsblk -rpo "name,type,size,mountpoint,label" | awk -F'[ ]' '$2=="part" && $4=="" {printf "%s %s (%s)\n",$5,$1,$3}')"
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit
 	echo "Android device(s) detected."


### PR DESCRIPTION
Adds an additional column to parse from lsblk to collect partition label. 

If partition labels exist I probably wrote them and they are probably useful, lets use them I guess.

Using this on system with multiple partitions of similar sizes, nice to be able to type the "human-readable" name of the partition if it exists

This changes dmenu prompt to print:
"[label] /path/ (size)" 
compared to the current:
"/path/ (size)"
(Now only if a label exists, otherwise will print as before)