### PR TITLE
Empty workspace switch

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -247,16 +247,16 @@ set $ws9 "9"
 set $ws10 "10"
 
 # switch to workspace
-bindsym $mod+1		workspace $ws1
-bindsym $mod+2		workspace $ws2
-bindsym $mod+3		workspace $ws3
-bindsym $mod+4		workspace $ws4
-bindsym $mod+5		workspace $ws5
-bindsym $mod+6		workspace $ws6
-bindsym $mod+7		workspace $ws7
-bindsym $mod+8		workspace $ws8
-bindsym $mod+9		workspace $ws9
-bindsym $mod+0		workspace $ws10
+bindsym $mod+1		workspace $ws1 exec i3switchempty $ws1
+bindsym $mod+2		workspace $ws2; exec i3switchempty $ws2
+bindsym $mod+3		workspace $ws3; exec i3switchempty $ws3
+bindsym $mod+4		workspace $ws4; exec i3switchempty $ws4
+bindsym $mod+5		workspace $ws5; exec i3switchempty $ws5
+bindsym $mod+6		workspace $ws6; exec i3switchempty $ws6
+bindsym $mod+7		workspace $ws7; exec i3switchempty $ws7
+bindsym $mod+8		workspace $ws8; exec i3switchempty $ws8
+bindsym $mod+9		workspace $ws9; exec i3switchempty $ws9
+bindsym $mod+0		workspace $ws10; exec i3switchempty $ws10
 
 # move focused container to workspace
 bindsym $mod+Shift+1	move container to workspace $ws1

--- a/.scripts/i3cmds/i3switchempty
+++ b/.scripts/i3cmds/i3switchempty
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Original sript below modified to not use `jq` for improved performance (~4 times as fast) and no dependencies.
+# https://github.com/tasinet/i3-switch-if-workspace-empty/blob/master/i3-switch-if-workspace-empty.sh
+
+new_workspace=$1
+
+if [ "" == "$new_workspace" ]; then
+    echo expecting workspace name/number
+    exit 1
+fi
+
+active_workspace=$(i3-msg -t get_workspaces | grep -Po '[0-9]*","visible":[a-z]*,"focused":true' | head -c1)
+
+toplevel_containers=$(i3-msg -t get_tree | grep -Po "\"num\":$active_workspace.*" | grep -Po '"nodes":(\d*?,|.*?[^\\]",)' | head -n1 | grep -Po '"nodes":\[\]')
+
+[ "$toplevel_containers" != "" ] && i3-msg workspace $new_workspace


### PR DESCRIPTION
Added script which switches to the workspace which a window is being moved to, if that action makes the current workspace empty. Idea from [here](https://github.com/tasinet/i3-switch-if-workspace-empty/blob/master/i3-switch-if-workspace-empty.sh). Modified to not use `jq` for improved performance (~4 times as fast) and no dependencies.

Can imagine this not being the preferred behavior for everyone but for me it greatly improves workflow. Try it out.