### PR TITLE
i3internet: strip leading whitespace from /proc/net/wireless output

### DIFF
--- a/.scripts/statusbar/i3internet
+++ b/.scripts/statusbar/i3internet
@@ -13,6 +13,6 @@ esac
 
 [ "$(cat /sys/class/net/w*/operstate)" = 'down' ] && wifiicon="📡"
 
-[ ! -n "${wifiicon+var}" ] && wifiicon=$(grep ^w /proc/net/wireless | awk '{ print "📶", int($3 * 100 / 70) "%" }')
+[ ! -n "${wifiicon+var}" ] && wifiicon=$(grep "^\s*w" /proc/net/wireless | awk '{ print "📶", int($3 * 100 / 70) "%" }')
 
 printf "%s %s" "$wifiicon" "$(cat /sys/class/net/e*/operstate | sed "s/down/❎/;s/up/🌐/")"


### PR DESCRIPTION
on my system 'grep ^w /proc/net/wireless' doesn't return a result due to
leading space being present in front of wlo1 wifi iface:

"  wlo1: 0000   55.  -55.  -256        0      0      0      0      5"

As a result the signal icon wasn't showing up. Solution is to strip it. Tested on T430s which was ok to begin with, no
regression.