### PR TITLE
Fix style when showing full weather report

### DIFF
--- a/.scripts/statusbar/weather
+++ b/.scripts/statusbar/weather
@@ -3,7 +3,7 @@
 location=""
 
 case $BLOCK_BUTTON in
-    1) $TERMINAL -e less -S ~/.weatherreport ;;
+    1) $TERMINAL -e less -Srf ~/.weatherreport ;;
     3) pgrep -x dunst >/dev/null && notify-send "<b>🌈 Weather module:</b>
 - Click for wttr.in forecast.
 ☔: Chance of rain/snow


### PR DESCRIPTION
When clicking on the weather report, the output was print dirty code instead of lines. This commit fixes this error.