### PR TITLE
Duplicate 'e' alias and added music i3block signal

### DIFF
--- a/.bmdirs
+++ b/.bmdirs
@@ -8,4 +8,3 @@ vv	~/Videos
 cf	~/.config
 sc	~/.scripts
 mn	/mnt
-e	/etc

--- a/.scripts/tools/lmc
+++ b/.scripts/tools/lmc
@@ -40,3 +40,4 @@ EOF
 esac
 
 pkill -RTMIN+10 i3blocks
+pkill -RTMIN+11 i3blocks


### PR DESCRIPTION
Noticed that the music i3block was not updating and the 'e' alias was not what was set in the .bashrc