### PR TITLE
Add option to mirror displays with internal display scaling

### DIFF
--- a/.scripts/i3cmds/displayselect
+++ b/.scripts/i3cmds/displayselect
@@ -11,7 +11,7 @@ twoscreen() { # If multi-monitor is selected and there are two screens.
     # Mirror displays using native resolution of external display and a scaled
     # version for the internal display
     if [ "$mirror" = "yes" ]; then
-        external=$(echo "$screens" | dmenu -i -p "Select external display:")
+        external=$(echo "$screens" | dmenu -i -p "Optimize resolution for:")
         internal=$(echo "$screens" | grep -v "$external")
 
         res_external=$(xrandr --query | sed -n "/^$external/,/\+/p" | \
@@ -27,7 +27,7 @@ twoscreen() { # If multi-monitor is selected and there are two screens.
         scale_x=$(echo "$res_ext_x / $res_int_x" | bc -l)
         scale_y=$(echo "$res_ext_y / $res_int_y" | bc -l)
 
-        xrandr --output "$external" --auto \
+        xrandr --output "$external" --auto --scale 1.0x1.0 \
             --output "$internal" --auto --same-as "$external" \
             --scale "$scale_x"x"$scale_y"
     else
@@ -35,7 +35,7 @@ twoscreen() { # If multi-monitor is selected and there are two screens.
         primary=$(echo "$screens" | dmenu -i -p "Select primary display:")
         secondary=$(echo "$screens" | grep -v "$primary")
         direction=$(printf "left\\nright" | dmenu -i -p "What side of $primary should $secondary be on?")
-        xrandr --output "$primary" --auto --output "$secondary" --"$direction"-of "$primary" --auto
+        xrandr --output "$primary" --auto --scale 1.0x1.0 --output "$secondary" --"$direction"-of "$primary" --auto --scale 1.0x1.0
     fi
     }
 

--- a/.scripts/i3cmds/displayselect
+++ b/.scripts/i3cmds/displayselect
@@ -6,11 +6,38 @@
 # I plan on adding a routine from multi-monitor setups later.
 
 twoscreen() { # If multi-monitor is selected and there are two screens.
-	primary=$(echo "$screens" | dmenu -i -p "Select primary display:")
-	secondary=$(echo "$screens" | grep -v "$primary")
-	direction=$(printf "left\\nright" | dmenu -i -p "What side of $primary should $secondary be on?")
-	xrandr --output "$primary" --auto --output "$secondary" --"$direction"-of "$primary" --auto
-	}
+
+    mirror=$(printf "no\\nyes" | dmenu -i -p "Mirror displays?")
+    # Mirror displays using native resolution of external display and a scaled
+    # version for the internal display
+    if [ "$mirror" = "yes" ]; then
+        external=$(echo "$screens" | dmenu -i -p "Select external display:")
+        internal=$(echo "$screens" | grep -v "$external")
+
+        res_external=$(xrandr --query | sed -n "/^$external/,/\+/p" | \
+            tail -n 1 | awk '{print $1}')
+        res_internal=$(xrandr --query | sed -n "/^$internal/,/\+/p" | \
+            tail -n 1 | awk '{print $1}')
+
+        res_ext_x=$(echo $res_external | sed 's/x.*//')
+        res_ext_y=$(echo $res_external | sed 's/.*x//')
+        res_int_x=$(echo $res_internal | sed 's/x.*//')
+        res_int_y=$(echo $res_internal | sed 's/.*x//')
+
+        scale_x=$(echo "$res_ext_x / $res_int_x" | bc -l)
+        scale_y=$(echo "$res_ext_y / $res_int_y" | bc -l)
+
+        xrandr --output "$external" --auto \
+            --output "$internal" --auto --same-as "$external" \
+            --scale "$scale_x"x"$scale_y"
+    else
+
+        primary=$(echo "$screens" | dmenu -i -p "Select primary display:")
+        secondary=$(echo "$screens" | grep -v "$primary")
+        direction=$(printf "left\\nright" | dmenu -i -p "What side of $primary should $secondary be on?")
+        xrandr --output "$primary" --auto --output "$secondary" --"$direction"-of "$primary" --auto
+    fi
+    }
 
 morescreen() { # If multi-monitor is selected and there are more than two screens.
 	primary=$(echo "$screens" | dmenu -i -p "Select primary display:")

--- a/.scripts/i3cmds/displayselect
+++ b/.scripts/i3cmds/displayselect
@@ -65,7 +65,7 @@ chosen=$(printf "%s\\nmulti-monitor\\nmanual selection" "$screens" | dmenu -i -p
 case "$chosen" in
 	"manual selection") arandr ; exit ;;
 	"multi-monitor") multimon ;;
-	*) xrandr --output "$chosen" --auto $(echo "$screens" | grep -v "$chosen" | awk '{print "--output", $1, "--off"}' | tr '\n' ' ') ;;
+	*) xrandr --output "$chosen" --auto --scale 1.0x1.0 $(echo "$screens" | grep -v "$chosen" | awk '{print "--output", $1, "--off"}' | tr '\n' ' ') ;;
 esac
 
 # Fix feh background if screen size/arangement has changed.


### PR DESCRIPTION
This addition allows the user to mirror the desktop across the internal and a single external display. I use this functionality for presentations, where I like to see the slides on my own display so I am turned towards the audience.

The external and internal displays use their preferred resolutions, but the internal display is scaled so that it spans the same desktop area as the external display.