### PR TITLE
fix showclip

### DIFF
--- a/.scripts/i3cmds/showclip
+++ b/.scripts/i3cmds/showclip
@@ -9,7 +9,7 @@ clip=$(xclip -o -selection clipboard)
 
 prim=$(xclip -o -selection primary)
 
-[ "$prim" != "" ] && notify-send "<b>Clipboard:</b>
+[ "$clip" != "" ] && notify-send "<b>Clipboard:</b>
 $clip"
-[ "$clip" != "" ] && notify-send "<b>Primary:</b>
+[ "$prim" != "" ] && notify-send "<b>Primary:</b>
 $prim"


### PR DESCRIPTION
Currently showclip doesn't work if either clipboard or primary selection is empty.
Before the change
```
echo prim | xclip -i -selection primary
echo "" | xclip -i -selection clipboard
```
shows that the clipboard is empty and doesn't show primary selection. It works correctly after swapping the variables.