### PR TITLE
Simplified ddspawn, no need for sleep

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -39,6 +39,8 @@ for_window [instance="tmuxdd"] resize set 625 450
 for_window [instance="tmuxdd"] move scratchpad
 for_window [instance="tmuxdd"] border pixel 3
 for_window [instance="tmuxdd"] sticky enable
+for_window [instance="tmuxdd"] scratchpad show
+for_window [instance="tmuxdd"] move position center
 
 # Then I have a window running R I use for basic arithmetic
 # I'll later bind this to mod+a.
@@ -47,6 +49,8 @@ for_window [instance="dropdowncalc"] resize set 800 300
 for_window [instance="dropdowncalc"] move scratchpad
 for_window [instance="dropdowncalc"] border pixel 2
 for_window [instance="dropdowncalc"] sticky enable
+for_window [instance="dropdowncalc"] scratchpad show
+for_window [instance="dropdowncalc"] move position center
 
 # #---Starting External Scripts---# #
 # Setting the background:

--- a/.scripts/i3cmds/ddspawn
+++ b/.scripts/i3cmds/ddspawn
@@ -6,7 +6,7 @@
 #	argument 1: script to run in dropdown window
 #	all other args are interpreted as options for your terminal
 # My usage:
-#	ddpawn
+#	ddspawn
 # bindsym $mod+u	exec --no-startup-id ddspawn tmuxdd
 #	Will hide/show window running the `tmuxdd` script when I press mod+u in i3
 # bindsym $mod+a	exec --no-startup-id ddspawn dropdowncalc -f mono:pixelsize=24
@@ -17,9 +17,8 @@
 if xwininfo -tree -root | grep "(\"$1\" ";
 then
 	echo "Window detected."
+	i3 "[instance=\"$1\"] scratchpad show; [instance=\"$1\"] move position center"
 else
 	echo "Window not detected... spawning."
-	i3 "exec --no-startup-id $TERMINAL -n $1 $(echo "$@" | cut -d ' ' -f2-) -e $1" && i3 "[instance=\"$1\"] scratchpad show; [instance=\"$1\"] move position center"
-	sleep .25 # This sleep is my laziness, will fix later (needed for immediate appearance after spawn).
+	i3 "exec --no-startup-id $1" 
 fi
-i3 "[instance=\"$1\"] scratchpad show; [instance=\"$1\"] move position center"


### PR DESCRIPTION
Moved scratchpad show into the i3 config file so dropdowns show right after spawning. This way there is no need to sleep in ddspawn