### PR TITLE
vifm dir preview, vicmd

### DIFF
--- a/.config/vifm/vifmrc
+++ b/.config/vifm/vifmrc
@@ -19,6 +19,7 @@ nmap <space> tj
 nmap q ZQ
 fileviewer *.html,*.css,*.py,*.c,*.h,*.sh,*.diff,*.tex highlight -O ansi %c
 fileview */ tree %c -L 1 --dirsfirst
+fileview ../ tree %c -L 1 --dirsfirst
 
 set vicmd=$EDITOR
 

--- a/.config/vifm/vifmrc
+++ b/.config/vifm/vifmrc
@@ -18,6 +18,9 @@ map bg :!setbg %f &<CR>
 nmap <space> tj
 nmap q ZQ
 fileviewer *.html,*.css,*.py,*.c,*.h,*.sh,*.diff,*.tex highlight -O ansi %c
+fileview */ tree %c -L 1 --dirsfirst
+
+set vicmd=$EDITOR
 
 set syscalls
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31730729/51146213-7de62680-1856-11e9-996f-69a22219b74c.png)
Better looking directory preview (in my opinion) using `tree` pacakge (0.11 MiB). `tree` output might be adjusted to your liking, e.g. different tree depth but this looked fine for most directories on my system.

Also was unable to open/edit files from within vifm which I solved by setting `vicmd=$EDITOR` but perhaps I'm missing a certain commit and you have a different solution for this.