### PR TITLE
Unplugged displays not being disabled in displayselect

### DIFF
--- a/.scripts/i3cmds/displayselect
+++ b/.scripts/i3cmds/displayselect
@@ -65,7 +65,7 @@ chosen=$(printf "%s\\nmulti-monitor\\nmanual selection" "$screens" | dmenu -i -p
 case "$chosen" in
 	"manual selection") arandr ; exit ;;
 	"multi-monitor") multimon ;;
-	*) xrandr --output "$chosen" --auto --scale 1.0x1.0 $(echo "$screens" | grep -v "$chosen" | awk '{print "--output", $1, "--off"}' | tr '\n' ' ') ;;
+	*) xrandr --output "$chosen" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$chosen" | awk '{print "--output", $1, "--off"}' | tr '\n' ' ') ;;
 esac
 
 setbg		# Fix background if screen size/arangement has changed.


### PR DESCRIPTION
This PR fixes scenarios where unplugged displays do not get turned off when changing selections through `displayselect`

In a scenario where `LVDS-1` and `HDMI-1` are active, if the user physically disconnect `HDMI-1` and uses `displayselect`, `HDMI-1` will not get disabled. This PR fixes this issue.