### PR TITLE
Showing the scratchpads initially is not necessary.

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -36,7 +36,6 @@ set $hibernate sudo -A systemctl suspend
 for_window [instance="dropdown_*"] floating enable
 for_window [instance="dropdown_*"] move scratchpad
 for_window [instance="dropdown_*"] sticky enable
-for_window [instance="dropdown_*"] scratchpad show
 for_window [instance="dropdown_tmuxdd"] resize set 625 450
 for_window [instance="dropdown_dropdowncalc"] resize set 800 300
 for_window [instance="dropdown_tmuxdd"] border pixel 3


### PR DESCRIPTION
The initial show for the scratchpad only makes them show up, when reloading i3, which is a bit annoying.
When calling `ddspawn`, they spawn nontheless.