### PR TITLE
Enable labels for drive mounting/unmounting

### DIFF
--- a/.scripts/i3cmds/dmenumount
+++ b/.scripts/i3cmds/dmenumount
@@ -16,11 +16,11 @@ getmount() { \
 	}
 
 mountusb() { \
-	keys=$(echo -e $usbdrives | awk '/name/{ if ($6 != "null") printf "%s (%s)\\n", $6, $4; else printf "%s (%s)\\n", $2, $4; }')
-	map=$(echo -e $usbdrives | awk '/name/{ if ($6 != "null") printf "[\"%s\"]=%s\n", $6, $2; else printf "[\"%s\"]=%s\n", $2, $2; }')
+	keys=$(echo -e "$usbdrives" | awk '{ printf "%s (%s)\\n", $2 != "null" ? $2 : $1, $3; }')
+	hmap=$(echo -e "$usbdrives" | awk '{ printf "[\"%s\"]=%s\n", $2 != "null" ? $2 : $1, $1; }')
 	device="$(echo -e "$keys" | sort -r | dmenu -i -p "Mount which drive?" | awk '{print $1}')"
 
-	eval declare -A devices=($map)
+	eval declare -A devices=($hmap)
 	chosen=${devices["$device"]}
 
 	sudo -A mount "$chosen" && notify-send -i "$PIX/usb.svg" "$chosen mounted." && exit 0
@@ -48,7 +48,9 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives=$(lsblk -Jplf -o name,size,label,type,mountpoint | tr -d " \"{}" | sed 's/:\|,/ /g' | awk /name/'{ if ($NF == "null" && $8 == "part") printf "%s\\n", $0; }')
+usbdrives=$(lsblk -Jplf -o name,label,size,type,mountpoint | tr -d " \"{}" | sed 's/:\|,/ /g' | awk '/name/ && $NF=="null" && $8=="part"{print $2, $4, $6; }')
+
+echo "$usbdrives"
 
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit

--- a/.scripts/i3cmds/dmenumount
+++ b/.scripts/i3cmds/dmenumount
@@ -23,7 +23,7 @@ mountusb() { \
 	eval declare -A devices=($hmap)
 	chosen=${devices["$device"]}
 
-	sudo -A mount "$chosen" && notify-send -i "$PIX/usb.svg" "$chosen mounted." && exit 0
+	sudo -A mount "$chosen" && notify-send -i "$PIX/usb.svg" "$device mounted." && exit 0
 	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
 	partitiontype="$(lsblk -no "fstype" "$chosen")"
 	case "$partitiontype" in

--- a/.scripts/i3cmds/dmenumount
+++ b/.scripts/i3cmds/dmenumount
@@ -16,7 +16,13 @@ getmount() { \
 	}
 
 mountusb() { \
-	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $1}')"
+	keys=$(echo -e $usbdrives | awk '/name/{ if ($6 != "null") printf "%s (%s)\\n", $6, $4; else printf "%s (%s)\\n", $2, $4; }')
+	map=$(echo -e $usbdrives | awk '/name/{ if ($6 != "null") printf "[\"%s\"]=%s\n", $6, $2; else printf "[\"%s\"]=%s\n", $2, $2; }')
+	device="$(echo -e "$keys" | sort -r | dmenu -i -p "Mount which drive?" | awk '{print $1}')"
+
+	eval declare -A devices=($map)
+	chosen=${devices["$device"]}
+
 	sudo -A mount "$chosen" && notify-send -i "$PIX/usb.svg" "$chosen mounted." && exit 0
 	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
 	partitiontype="$(lsblk -no "fstype" "$chosen")"
@@ -24,7 +30,7 @@ mountusb() { \
 		"vfat") sudo -A mount -t vfat "$chosen" "$mp" -o rw,umask=0000;;
 		*) sudo -A mount "$chosen" "$mp"; user="$(whoami)"; ug="$(groups | awk '{print $1}')"; sudo -A chown "$user":"$ug" 741 "$mp";;
 	esac
-	notify-send -i "$PIX/usb.svg" "$chosen mounted to $mp."
+	notify-send -i "$PIX/usb.svg" "$device mounted to $mp."
 	}
 
 mountandroid() { \
@@ -42,7 +48,7 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint" | awk '$2=="part"&&$4==""{printf "%s (%s)\n",$1,$3}')"
+usbdrives=$(lsblk -Jplf -o name,size,label,type,mountpoint | tr -d " \"{}" | sed 's/:\|,/ /g' | awk /name/'{ if ($NF == "null" && $8 == "part") printf "%s\\n", $0; }')
 
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit

--- a/.scripts/i3cmds/dmenuumount
+++ b/.scripts/i3cmds/dmenuumount
@@ -5,9 +5,16 @@
 
 unmountusb() {
 	[ -z "$drives" ] && exit
-	chosen=$(echo "$drives" | dmenu -i -p "Unmount which drive?" | awk '{print $1}')
+
+	keys=$(echo -e $drives | awk '/name/{ if ($6 != "null") printf "%s (%s)\\n", $6, $4; else printf "%s (%s)\\n", $2, $4; }')
+	map=$(echo -e $drives | awk '/name/{ if ($6 != "null") printf "[\"%s\"]=%s\n", $6, $2; else printf "[\"%s\"]=%s\n", $2, $2; }')
+	chosen="$(echo -e "$keys" | sort -r | dmenu -i -p "Unmount which drive?" | awk '{print $1}')"
+
+	eval declare -A devices=($map)
+	mp=${devices["$chosen"]}
+
 	[ -z "$chosen" ] && exit
-	sudo -A umount "$chosen" && pgrep -x dunst && notify-send -i "$PIX/usb.svg" "$chosen unmounted."
+	sudo -A umount "$mp" && pgrep -x dunst && notify-send -i "$PIX/usb.svg" "$chosen unmounted."
 	}
 
 unmountandroid() { \
@@ -23,7 +30,7 @@ asktype() { \
 	esac
 	}
 
-drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$2=="part"&&$4!~/\/boot|\/home$|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
+drives=$(lsblk -Jplf -o name,size,label,type,mountpoint | tr -d " \"{}" | sed 's/:\|,/ /g' | awk /name/'{ if ($NF != "null" && $NF !~/\/boot|\/home$|SWAP/&&length($NF)>1 && $8 == "part") printf "%s\\n", $0; }')
 
 if ! grep simple-mtpfs /etc/mtab; then
 	[ -z "$drives" ] && echo "No drives to unmount." &&  exit

--- a/.scripts/i3cmds/dmenuumount
+++ b/.scripts/i3cmds/dmenuumount
@@ -6,11 +6,11 @@
 unmountusb() {
 	[ -z "$drives" ] && exit
 
-	keys=$(echo -e $drives | awk '/name/{ if ($6 != "null") printf "%s (%s)\\n", $6, $4; else printf "%s (%s)\\n", $2, $4; }')
-	map=$(echo -e $drives | awk '/name/{ if ($6 != "null") printf "[\"%s\"]=%s\n", $6, $2; else printf "[\"%s\"]=%s\n", $2, $2; }')
+	keys=$(echo -e "$drives" | awk '{ printf "%s (%s)\n", $2 != "null" ? $2 : $1, $3; }')
+	hmap=$(echo -e "$drives" | awk '{ printf "[\"%s\"]=%s\n", $2 != "null" ? $2 : $1, $1; }')
 	chosen="$(echo -e "$keys" | sort -r | dmenu -i -p "Unmount which drive?" | awk '{print $1}')"
 
-	eval declare -A devices=($map)
+	eval declare -A devices=($hmap)
 	mp=${devices["$chosen"]}
 
 	[ -z "$chosen" ] && exit
@@ -30,7 +30,7 @@ asktype() { \
 	esac
 	}
 
-drives=$(lsblk -Jplf -o name,size,label,type,mountpoint | tr -d " \"{}" | sed 's/:\|,/ /g' | awk /name/'{ if ($NF != "null" && $NF !~/\/boot|\/home$|SWAP/&&length($NF)>1 && $8 == "part") printf "%s\\n", $0; }')
+drives=$(lsblk -Jplf -o name,label,size,type,mountpoint | tr -d " \"{}" | sed 's/:\|,/ /g' | awk '/name/ && $NF != "null" && $NF !~/\/boot|\/home$|SWAP/&&length($NF)>1 && $8=="part" {print $2, $4, $6;}')
 
 if ! grep simple-mtpfs /etc/mtab; then
 	[ -z "$drives" ] && echo "No drives to unmount." &&  exit


### PR DESCRIPTION
I found it kinda annoying to use `lsblk` to find which drive to mount even though there are labels for the partitions. So I added labels to the mount/umount dmenu if the drives have it.