### PR TITLE
Added window id from xdotool in mainpick.

### DIFF
--- a/.scripts/i3cmds/maimpick
+++ b/.scripts/i3cmds/maimpick
@@ -4,6 +4,6 @@ case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area
 	"current window") maim -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
 	"full screen") maim pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;
 	"a selected area (copy)") maim -s | xclip -selection clipboard -t image/png ;;
-	"current window (copy)") maim -i | xclip -selection clipboard -t image/png ;;
+	"current window (copy)") maim -i "$(xdotool getactivewindow)" | xclip -selection clipboard -t image/png ;;
 	"full screen (copy)") maim | xclip -selection clipboard -t image/png ;;
 esac

--- a/.scripts/i3cmds/maimpick
+++ b/.scripts/i3cmds/maimpick
@@ -1,5 +1,5 @@
 #!/bin/sh
-case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfullscreen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
+case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
 	"a selected area") maim -s pic-selected-"$(date '+%y%m%d-%H%M-%S').png" ;;
 	"current window") maim -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
 	"full screen") maim pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;


### PR DESCRIPTION
Copied a similar parameter `"$(xdotool getactivewindow)"` from the second option (a.k.a "current window") to the fifth.

---

It is quite strange why the argument for "-i" is missing in the fifth option? At least I came up with some issues which complained:
```
terminate called after throwing an instance of 'cxxopts::missing_argument_exception'
  what():  Option ‘i’ is missing an argument
```