### PR TITLE
Made dunst a user systemd service

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -46,8 +46,6 @@ for_window [instance="dropdown_*"] move position center
 # #---Starting External Scripts---# #
 # Setting the background:
 exec --no-startup-id setbg
-# Starts dunst for notifications:
-exec --no-startup-id dunst
 # Composite manager:
 exec --no-startup-id xcompmgr
 # Runs the key remapping scripts

--- a/.config/systemd/user/dunst.service
+++ b/.config/systemd/user/dunst.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=dunst notifications
+
+[Service]
+Type=simple
+Environment=DISPLAY=:0
+ExecStart=dunst
+
+[Install]
+WantedBy=default.target

--- a/.scripts/i3cmds/displayselect
+++ b/.scripts/i3cmds/displayselect
@@ -70,4 +70,4 @@ esac
 
 setbg		# Fix background if screen size/arangement has changed.
 remaps		# Re-remap keys if keyboard added (for laptop bases)
-pgrep -x dunst >/dev/null && killall dunst && setsid dunst & # Restart dunst to ensure proper location on screen
+systemctl --user restart dunst # Restart dunst to ensure proper location on screen


### PR DESCRIPTION
Created a user systemd service for dunst. A more concrete setup for something that is constantly running in the background and gives easy access to control and logs from anywhere.

By running `systemd --user enable dunst` it will start on login.

Then you can do `systemd --user status dunst` to check if its running

`systemd --user restart dunst`, `systemd --user start dunst`, `systemd --user stop dunst`, etc.