### PR TITLE
remove a trailing colon from the PATH

### DIFF
--- a/.profile
+++ b/.profile
@@ -2,7 +2,7 @@
 # Profile file. Runs on login.
 
 # Adds `~/.scripts` and all subdirectories to $PATH
-export PATH="$PATH:$(du "$HOME/.scripts/" | cut -f2 | tr '\n' ':')"
+export PATH="$PATH:$(du "$HOME/.scripts/" | cut -f2 | tr '\n' ':' | sed 's/:*$//')"
 export EDITOR="nvim"
 export TERMINAL="st"
 export BROWSER="firefox"


### PR DESCRIPTION
The last entry in this path will always have a trailing colon which can cause issues. I've tested it on a new temp user. this should do the trick.