### PR TITLE
Use `find` instead of `du | awk`

### DIFF
--- a/.config/aliasrc
+++ b/.config/aliasrc
@@ -28,6 +28,6 @@ alias ka="killall" \
 command -v nvim >/dev/null && alias vim="nvim" vimdiff="nvim -d" # Use neovim for vim if present.
 
 shdl() { curl -O $(curl -s http://sci-hub.tw/"$@" | grep location.href | grep -o http.*pdf) ;}
-se() { du -a ~/.scripts/* ~/.config/* | awk '{print $2}' | fzf | xargs  -r $EDITOR ;}
-sv() { vcopy "$(du -a ~/.scripts/* ~/.config/* | awk '{print $2}' | fzf)" ;}
+se() { find ~/.scripts/* ~/.config/* -type f | fzf | xargs  -r $EDITOR ;}
+sv() { vcopy "$(find ~/.scripts/* ~/.config/* -type f | fzf)" ;}
 vf() { fzf | xargs -r -I % $EDITOR % ;}


### PR DESCRIPTION
On my system (x220, arch, ssd) it is significantly faster to use `find ...` instead of `du ... | awk ...`. This can speed up fuzzy file finding.

```
$ time (du -a ~ | awk '{print $2}' >du_awk.txt)
( du -a ~ | awk '{print $2}' > du_awk.txt; )  1.20s user 2.79s system 155% cpu 2.569 total

$ time (find ~ -type f >find.txt)
( find ~ -type f > find.txt; )  0.27s user 0.63s system 98% cpu 0.915 total

$ sort du_awk.txt >du_awk.txt && sort find.txt >find.txt && diff du_awk.txt find.txt
[ no output ]
```