### PR TITLE
change rotdir to use ed(1)

### DIFF
--- a/.scripts/tools/rotdir
+++ b/.scripts/tools/rotdir
@@ -1,3 +1,16 @@
 #!/bin/sh
-# Give this script a filename argument. Returns PWD rotated with that file first.
-ls "$PWD" | awk "BEGIN { lines = \"\"; m = 0; } /^$1$/ { m = 1; } { if (!m) { if (lines) { lines = lines\"\n\"; } lines = lines\"\"\$0; } else { print \$0; } } END { print lines; }"
+if [ -z "$1" ]; then
+	echo usage: rotdir regex 2>&1
+	exit 1;
+fi
+
+ed -s <<EOF
+# Read in all files in the current dir
+r !find "$PWD" -maxdepth 1
+# Search all lines for regex, move to top
+g/$1/m0
+# Print all lines
+,p
+# Force quit
+Q
+EOF


### PR DESCRIPTION
`rotdir` currently uses `awk(1)` to save a list of files in a string. The use of string concatenation becomes costly proportional to the number of files to be filtered. This job is more suited to line editors like `ed(1)` and `ex(1)`.

The revised `rotdir` script uses `ed` to filter all files that match the first argument to the top of the buffer. It then prints and quits. Rudimentary error checking on the regex has been added as well.

I chose `ed` not just because it's the standard text editor, but I found that different `ex` implementations produced differing results. If you are using Arch, you will have to install a POSIX compliant `ed` --- either GNU ed or compiling a BSD one --- as it doesn't come with it by default.