### PR TITLE
point the help button to the correct file

### DIFF
--- a/.scripts/statusbar/help
+++ b/.scripts/statusbar/help
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 case $BLOCK_BUTTON in
-    1) groff -mom ~/.readme.mom -Tpdf | zathura - ;;
+    1) groff -kejpt -mom ~/.local/share/larbs/readme.mom -Tpdf | zathura - ;;
     3) pgrep -x dunst >/dev/null && notify-send "<b>❓ Help module:</b>
 - Left click to open LARBS guide.";;
 esac


### PR DESCRIPTION
Don't know if anyone actually uses the help button in the status bar but it was pointing to the old location.

Also copied the flags over from the mod+F1 hotkey.