### PR TITLE
raw control chars in less, no "ESC" anymore

### DIFF
--- a/.scripts/statusbar/weather
+++ b/.scripts/statusbar/weather
@@ -2,7 +2,7 @@
 [ "$(stat -c %y /tmp/weatherreport | awk '{print $1}')" != "$(date '+%Y-%m-%d')" ] && getforecast
 
 case $BLOCK_BUTTON in
-    1) $TERMINAL -e less -S /tmp/weatherreport ;;
+    1) $TERMINAL -e less -S -R /tmp/weatherreport ;;
     3) pgrep -x dunst >/dev/null && notify-send "<b>🌈 Weather module:</b>
 - Click for wttr.in forecast.
 ☔: Chance of rain/snow


### PR DESCRIPTION
My weatherreport was full with ESC and other control chars. Using the -R flag for less makes it pretty again.