### PR TITLE
Prune existing mountpoints from find in dmenumount

### DIFF
--- a/.scripts/i3cmds/dmenumount
+++ b/.scripts/i3cmds/dmenumount
@@ -18,7 +18,8 @@ getmount() { \
 mountusb() { \
 	chosen="$(echo "$usbdrives" | dmenu -i -p "Mount which drive?" | awk '{print $1}')"
 	sudo -A mount "$chosen" && notify-send "$chosen mounted." && exit 0
-	getmount "/mnt /media /mount /home -maxdepth 5 -type d"
+	alreadymounted=$(lsblk -nrpo "name,type,mountpoint" | awk '$2=="part"&&$3!~/\/boot|\/home$|SWAP/&&length($3)>1{printf "-not \( -path *%s -prune \) \ \n",$3}')
+	getmount "/mnt /media /mount /home -maxdepth 5 -type d $alreadymounted"
 	partitiontype="$(lsblk -no "fstype" "$chosen")"
 	case "$partitiontype" in
 		"vfat") sudo -A mount -t vfat "$chosen" "$mp" -o rw,umask=0000;;


### PR DESCRIPTION
This speeds up the mounting process if you already have drives mounted
containing a large number of folders. Since 2 drives cannot be mounted in
the same folder anyway, these are now excluded from the the find
command, speeding up the mounting process.