### PR TITLE
mod+shift+q forcekills window

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -82,7 +82,7 @@ bindsym $mod+Insert		exec --no-startup-id showclip
 
 # #---Letter Key Bindings---# #
 bindsym $mod+q			[con_id="__focused__" instance="^(?!dropdown_).*$"] kill
-bindsym $mod+Shift+q		exec --no-startup-id forcekill
+bindsym $mod+Shift+q		[con_id="__focused__" instance="^(?!dropdown_).*$"] exec --no-startup-id kill -9 `xdotool getwindowfocus getwindowpid`
 
 bindsym $mod+w			exec $term -e nmtui
 bindsym $mod+Shift+w		exec --no-startup-id $BROWSER

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -82,7 +82,7 @@ bindsym $mod+Insert		exec --no-startup-id showclip
 
 # #---Letter Key Bindings---# #
 bindsym $mod+q			[con_id="__focused__" instance="^(?!dropdown_).*$"] kill
-bindsym $mod+Shift+q		[con_id="__focused__" instance="^(?!dropdown_).*$"] kill
+bindsym $mod+Shift+q		exec --no-startup-id forcekill
 
 bindsym $mod+w			exec $term -e nmtui
 bindsym $mod+Shift+w		exec --no-startup-id $BROWSER

--- a/.scripts/i3cmds/forcekill
+++ b/.scripts/i3cmds/forcekill
@@ -1,0 +1,4 @@
+#!/bin
+# force kills any focused window, handy in case if a window hangs
+focusid="$(xdotool getwindowfocus getwindowpid)"
+kill -9 $focusid


### PR DESCRIPTION
In case if a window/program hangs, you can now easily kill it with mod+shift+q