### PR TITLE
create 'locker'

### DIFF
--- a/.scripts/tools/locker
+++ b/.scripts/tools/locker
@@ -1,0 +1,12 @@
+#!/bin/sh
+# option to use suckless slock as well - just put "slock" for both variables below
+lockprogram="i3lock"
+lockcmd="i3lock -e -f -c 120201"
+$lockcmd && xset dpms force off
+batterystatus=$(cat /sys/class/power_supply/BAT?/status)
+if [[ ! -z $(pgrep $lockprogram)  && $batterystatus=="Discharging" ]];then
+  sleep 10m
+  if [[ ! -z $(pgrep $lockprogram)  && $batterystatus=="Discharging" ]];then
+    systemctl suspend
+  fi
+fi


### PR DESCRIPTION
I just added a pull request to the LARBS repo (https://github.com/LukeSmithxyz/LARBS/pull/126) to add xautolock. It's fairly useful. If you put `xautolock -locker locker` in the i3 config, it'll invoke i3lock after 5 minutes, and if the computer is on battery power, should suspend it 10 minutes after that. If the machine is unlocked (i3lock goes away) or plugged in, it should not invoke sleep.