### PR TITLE
Set Symbola as the fallback font for monospace fonts

### DIFF
--- a/.config/fontconfig/fonts.conf
+++ b/.config/fontconfig/fonts.conf
@@ -19,6 +19,12 @@
     <prefer><family>Inconsolata</family></prefer>
   </alias>
 
+   <!-- This sets Symbola as the final fallback font for the monospace font family. -->
+  <match target="pattern">
+        <test name="family"><string>monospace</string></test>
+        <edit name="family" mode="append"><string>Symbola</string></edit>
+    </match>
+
 </fontconfig>
 
 


### PR DESCRIPTION
Avoids that `st` crashes when colored emoji fonts are installed.
These get sometimes chosen as the final fallback font for unknown glyphs.
However, `st` cannot handle colored emojis.

If `st` is still crashing, this might be caused by a user-defined override in `/etc/fonts/*`.