### PR TITLE
Fix for spawning scripts that require no args

### DIFF
--- a/.scripts/i3cmds/ddspawn
+++ b/.scripts/i3cmds/ddspawn
@@ -7,11 +7,13 @@
 
 [ -z "$1" ] && exit
 
-if xwininfo -tree -root | grep "(\"dropdown_$1\" ";
+script=$1
+shift
+if xwininfo -tree -root | grep "(\"dropdown_$script\" ";
 then
 	echo "Window detected."
-	i3 "[instance=\"dropdown_$1\"] scratchpad show; [instance=\"dropdown_$1\"] move position center"
+	i3 "[instance=\"dropdown_$script\"] scratchpad show; [instance=\"dropdown_$script\"] move position center"
 else
 	echo "Window not detected... spawning."
-	i3 "exec --no-startup-id $TERMINAL -n dropdown_$1 ${@:2} -e $1"
+	i3 "exec --no-startup-id $TERMINAL -n dropdown_$script $@ -e $script"
 fi

--- a/.scripts/i3cmds/ddspawn
+++ b/.scripts/i3cmds/ddspawn
@@ -13,5 +13,5 @@ then
 	i3 "[instance=\"dropdown_$1\"] scratchpad show; [instance=\"dropdown_$1\"] move position center"
 else
 	echo "Window not detected... spawning."
-	i3 "exec --no-startup-id $TERMINAL -n dropdown_$1 $(echo "$@" | cut -d ' ' -f2-) -e $1"
+	i3 "exec --no-startup-id $TERMINAL -n dropdown_$1 ${@:2} -e $1"
 fi


### PR DESCRIPTION
For example, "ddspawn vifm" is generating the failing commad "st vifm -e vifm" without this fix.
This proposed change fixes this issue so that "ddspawn vifm" generates the correct "st -e vifm". It also simplify  the i3 command in my view.
Thanks for sharing this helpful script, I used it everywhere!