### PR TITLE
fix tmux config renames

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,13 +1,13 @@
 set -g prefix C-a
 setw -g mode-keys vi
-#setw -g mode-bg black
+setw -g mode-style bg=black
 set-option -g default-terminal "xterm-256color"
-#set-option -g pane-active-border-fg green
+set-option -g pane-active-border-style fg=green
 set-window-option -g xterm-keys on # for vim
 set-window-option -g mode-keys vi # vi key
 set-window-option -g monitor-activity on
-#set-window-option -g window-status-current-fg white
-#setw -g window-status-current-attr reverse
+set-window-option -g window-status-current-style fg=white
+setw -g window-status-current-style reverse
 setw -g automatic-rename
 set -g mouse on
 set -g history-limit 30000
@@ -36,7 +36,7 @@ bind-key -n C-up prev
 bind-key -n C-left prev
 bind-key -n C-right next
 bind-key -n C-down next
-#set-window-option -g window-status-current-bg red
+set-window-option -g window-status-current-style bg=red
 bind C-j previous-window
 bind C-k next-window
 #bind-key C-a last-window # C-a C-a for last active window


### PR DESCRIPTION
`#bind-key C-a last-window # C-a C-a for last active window` didn't need renaming for me, why did you comment it out?
you uncomment it out before merging.

[more info](https://github.com/tmux/tmux/issues/1689)