### PR TITLE
Set system locale to international

### DIFF
--- a/.local/bin/statusbar/memory
+++ b/.local/bin/statusbar/memory
@@ -6,4 +6,7 @@ case $BLOCK_BUTTON in
 - Click to show memory hogs." ;;
 esac
 
-free -h | awk '/^Mem:/ {print $3 "/" $2}'
+# Set language to international or otherwise 'free' will output in the current
+# system language
+LC_ALL=C free -h | awk '/^Mem:/ {print $3 "/" $2}'
+


### PR DESCRIPTION
Running `free` without any modifications will result in the output being
localized into the current system-language (i.e. German if you're running a
German install of Linux). The parsing of the `memory` script however relies
on the output being in english (US).

As an easy fix we just set the system locale tempoararily to 'C' (which is the
_default_ language, i.e. english in case of `free`).