### PR TITLE
Dmenu script for monitor selection checks scripts.

### DIFF
--- a/.local/bin/i3cmds/displayselect
+++ b/.local/bin/i3cmds/displayselect
@@ -55,13 +55,13 @@ multimon() { # Multi-monitor handler.
 	esac ;}
 
 loadconf() { # Load an existing configuration file saved from arandr
-	scripts=$(ls ~/.screenlayout/)
+	scripts=$(ls ~/.config/screenlayout/)
 	if [ -z "$scripts" ]; then
 		scripts="None"
 	fi
 	chosen=$(for s in $scripts; do echo $s; done | dmenu -i -p "Select configuration file:") &&
 	case "$chosen" in
-		*sh) ~/.screenlayout/$chosen ;;
+		*sh) ~/.config/screenlayout/"$chosen" ;;
 		*) exit ;;
 	esac ;}
 

--- a/.local/bin/i3cmds/displayselect
+++ b/.local/bin/i3cmds/displayselect
@@ -54,6 +54,17 @@ multimon() { # Multi-monitor handler.
 		*) morescreen ;;
 	esac ;}
 
+loadconf() { # Load an existing configuration file saved from arandr
+	scripts=$(ls ~/.screenlayout/)
+	if [ -z "$scripts" ]; then
+		scripts="None"
+	fi
+	chosen=$(for s in $scripts; do echo $s; done | dmenu -i -p "Select configuration file:") &&
+	case "$chosen" in
+		*sh) ~/.screenlayout/$chosen ;;
+		*) exit ;;
+	esac ;}
+
 # Get all possible displays
 allposs=$(xrandr -q | grep "connected")
 
@@ -61,10 +72,11 @@ allposs=$(xrandr -q | grep "connected")
 screens=$(echo "$allposs" | grep " connected" | awk '{print $1}')
 
 # Get user choice including multi-monitor and manual selection:
-chosen=$(printf "%s\\nmulti-monitor\\nmanual selection" "$screens" | dmenu -i -p "Select display arangement:") &&
+chosen=$(printf "%s\\nmulti-monitor\\nexisting conf\\nmanual selection" "$screens" | dmenu -i -p "Select display arangement:") &&
 case "$chosen" in
 	"manual selection") arandr ; exit ;;
 	"multi-monitor") multimon ;;
+	"existing conf") loadconf ;;
 	*) xrandr --output "$chosen" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$chosen" | awk '{print "--output", $1, "--off"}' | tr '\n' ' ') ;;
 esac
 

--- a/.local/share/larbs/readme.mom
+++ b/.local/share/larbs/readme.mom
@@ -207,7 +207,8 @@ Naturally, you can use \f(CWyay\fP to look for and install any you want to add.
 .ITEM
 \f(CWMod+F2\fP \(en Refresh i3
 .ITEM
-\f(CWMod+F3\fP \(en Select screen/display to use
+\f(CWMod+F3\fP \(en Select screen/display to use.
+You can save ARandR configurations in \f(CW~/.config/screenlayout\fP and load them here
 .ITEM
 \f(CWMod+F4\fP \(en Hibernate (will ask to confirm)
 .ITEM


### PR DESCRIPTION
When using multiple monitors, the current configuration may not be enough (e.g., a vertical screen), which forces to use manual selection and arandr.
Arandr allows to save the configuration in a shell script for future use.
I think it would be handy to be able to select existing scripts from the dmenu monitor selector.

The dmenu now checks for shell scripts under ~/.screenlayouts (which need to be created from arandr) and allows to pick one of them.
