### PR TITLE
Update .profile

### DIFF
--- a/.profile
+++ b/.profile
@@ -2,7 +2,7 @@
 # Profile file. Runs on login.
 
 # Adds `~/.scripts` and all subdirectories to $PATH
-export PATH="$PATH:$(du "$HOME/.local/bin/" | cut -f2 | tr '\n' ':' | sed 's/:*$//')"
+export PATH="$PATH:$(find "$HOME/.local/bin/" -type d | tr '\n' ':' | sed 's/:*$//')"
 export EDITOR="nvim"
 export TERMINAL="st"
 export BROWSER="firefox"


### PR DESCRIPTION
One command less (removes `cut`) when exporting PATH. I know you don't like `find` but is faster here. Is posix, although is not part of Plan9.