### PR TITLE
mailsync and mpd problems

### DIFF
--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -102,7 +102,7 @@ super + F7
 	td-togggle
 # sync email
 super + F8
-	mailsync
+	.config/mutt/etc/mailsync.sh
 # Mount a USB drive or Android device
 super + F9
 	dmenumount

--- a/.xprofile
+++ b/.xprofile
@@ -10,4 +10,5 @@ xset r rate 300 50 &	# Speed xrate up
 unclutter &		# Remove mouse when idle
 xcompmgr &		# xcompmgr for transparency
 dunst &			# dunst for notifications
-mpdupdate &
+mpd &
+sleep 5; mpdupdate &


### PR DESCRIPTION
mailsync does not seem to work. Replacing by the full path .config/mutt/etc/mailsync.sh