### PR TITLE
add dmenu script for power state management under a single command

### DIFF
--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -36,9 +36,7 @@ super + Scroll_Lock
 super + Insert
 	showclip
 super + shift + x
-	prompt "Shutdown computer?" "sudo -A shutdown -h now"
-super + shift + BackSpace
-	prompt "Reboot computer?" "sudo -A shutdown -r now"
+	dmenulogout
 super + x
 	mpc pause; pauseallmpv; i3lock -e -f -c 1d2021; xset dpms force off
 XF86Launch1

--- a/.local/bin/i3cmds/dmenulogout
+++ b/.local/bin/i3cmds/dmenulogout
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+MESSAGE="lock\\nexit\\nsuspend\\nhibernate\\nreboot\\nshutdown"
+ACTION="$(printf "$MESSAGE" | dmenu -l 6 -i -p "Do what now?")"
+
+case "$ACTION" in
+    "lock") i3lock -n -c 222222 ;;
+    "exit") i3-msg exit ;;
+    "suspend") systemctl suspend ;;
+    "hibernate") systemctl hibernate ;;
+    "reboot") systemctl reboot ;;
+    "shutdown") systemctl poweroff -i ;;
+esac


### PR DESCRIPTION
You can abscract the lock and exit options into their own functions, scripts, or env variable to be set to whatever you want.

I have my screen lock command in its own script which is then fed to dmenulogout and xxs-lock to keep my lock screen consistent.

There are many ways to do this, I have found this to be very portable whilst uncluttering my i3 and sxhkd bindings.