### PR TITLE
Added mpd in .xprofile

### DIFF
--- a/.xprofile
+++ b/.xprofile
@@ -10,4 +10,5 @@ xset r rate 300 50 &	# Speed xrate up
 unclutter &		# Remove mouse when idle
 xcompmgr &		# xcompmgr for transparency
 dunst &			# dunst for notifications
+mpd &
 mpdupdate &


### PR DESCRIPTION
When I launch ncmpcpp, it shows "**ncmpcpp: connection refused**". I had to run `mpd` in terminal manually in order for ncmpcpp to work. Added this to `.xprofile` so it runs automatically every time on boot.