### PR TITLE
dmenupassword - a script to quickly copy passwords stored in pass to the clipboard

### DIFF
--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -115,5 +115,6 @@ super + F11
 # Network Manager interface
 super + F12
 	$TERMINAL -e sudo -A nmtui
-
+super + Shift + F1
+	dmenupassword
 

--- a/.config/vifm/colors/luke.vifm
+++ b/.config/vifm/colors/luke.vifm
@@ -1,5 +1,5 @@
 highlight clear
-highlight Win cterm=none ctermfg=white ctermbg=black
+highlight Win cterm=none ctermfg=white ctermbg=default
 highlight Directory cterm=bold ctermfg=cyan ctermbg=default
 highlight Link cterm=bold ctermfg=blue ctermbg=default
 highlight BrokenLink cterm=bold ctermfg=red ctermbg=default

--- a/.config/vifm/colors/luke.vifm
+++ b/.config/vifm/colors/luke.vifm
@@ -13,9 +13,9 @@ highlight TopLine cterm=none ctermfg=black ctermbg=white
 highlight TopLineSel cterm=bold ctermfg=black ctermbg=default
 highlight StatusLine cterm=bold ctermfg=black ctermbg=blue
 highlight WildMenu cterm=underline,reverse ctermfg=white ctermbg=black
-highlight CmdLine cterm=none ctermfg=white ctermbg=black
+highlight CmdLine cterm=none ctermfg=white ctermbg=default
 highlight ErrorMsg cterm=none ctermfg=red ctermbg=black
-highlight Border cterm=none ctermfg=white ctermbg=black
+highlight Border cterm=none ctermfg=white ctermbg=default
 highlight JobLine cterm=bold,reverse ctermfg=black ctermbg=white
 highlight SuggestBox cterm=bold ctermfg=default ctermbg=default
 highlight CmpMismatch cterm=bold ctermfg=white ctermbg=red

--- a/.local/bin/i3cmds/dmenupassword
+++ b/.local/bin/i3cmds/dmenupassword
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Gives a dmenu prompt to copy password stored in pass database in the clipboard
+# (See man pass for more details)
+
+getpass() { \
+	echo "" | xclip -selection clipboard
+	account="$(find ~/.password-store/ -name "*.gpg" | sed 's/.*\///g;s/.gpg$//'| dmenu -i -p "Choose account")"
+	[ "$account" = "" ] && exit 1
+	pass -c $account 2&>1 /dev/null && notify-send "Password for $account stored in clipboard for 45 s ⌛ " && exit 0
+	}
+getpass

--- a/.local/share/larbs/readme.mom
+++ b/.local/share/larbs/readme.mom
@@ -231,6 +231,8 @@ is installed.
 .ITEM
 \f(CWMod+F12\fP \(en \f(CWnmtui\fP for selecting the wireless internet source.
 .ITEM
+\f(CWMod+Shift+F1\fP \(en Copy a password stored in Pass in the clipboard for 45 s
+.ITEM
 \f(CWMod+`\fP \(en Select an emoji to copy to clipboard
 .ITEM
 \f(CWMod+Insert\fP \(en Show contents of clipboard/primary selection

--- a/.xprofile
+++ b/.xprofile
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 setbg &		# Set the background
-sxhkd &	# Bind keys
+sxhkd -m 1 &	# Bind keys
 # Switch to US international with Caps as Mod/Escape
 setxkbmap -option caps:super -variant altgr-intl && killall xcape 2>/dev/null ; xcape -e 'Super_L=Escape' &
 # Properties button extra Mod/Escape


### PR DESCRIPTION
This commit aims to provide a mean to quickly access passwords stored in .password-store directory without using the mouse.
Thanks to this script, you can easily access the password required to login to one of your accounts within a web browser for example : 

- Ctrl+Shift+F1
- Choose your account and press enter
- Ctrl+v in the password field