### PR TITLE
A more elegant way to add ~/.local/bin directories recursively to the path.

### DIFF
--- a/.local/bin/SCRIPTS.md
+++ b/.local/bin/SCRIPTS.md
@@ -5,7 +5,7 @@ into sub-directories for easy management, and all are seamlessly added to
 `$PATH` with the command below in `~/.profile`:
 
 ```
-export PATH="$(du $HOME/.local/bin/ | cut -f2 | tr '\n' ':')$PATH"
+export PATH="$PATH:$(find "$HOME/.local/bin/" -type d | paste -sd:)"
 ```
 
 ## `statusbar/`

--- a/.profile
+++ b/.profile
@@ -2,7 +2,7 @@
 # Profile file. Runs on login.
 
 # Adds `~/.local/bin/` and all subdirectories to $PATH
-export PATH="$PATH:$(du "$HOME/.local/bin/" | cut -f2 | tr '\n' ':' | sed 's/:*$//')"
+export PATH="$PATH:$(find "$HOME/.local/bin/" -type d | paste -sd: )"
 export EDITOR="nvim"
 export TERMINAL="st"
 export BROWSER="firefox"


### PR DESCRIPTION
Just a subtle change to how the directories nested in `~/.local/bin` are added to `$PATH` in `~/.profile`. It now uses `find $HOME/.local/bin -type d` to list recusively only the directories (not files), and GNU `paste` to join the lines together with a colon delimiter.

I've also updated the relevant documentation.