### PR TITLE
setsid cant open $BROWSER with double quotes

### DIFF
--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -18,5 +18,5 @@ case "$1" in
 		setsid tsp curl -LO "$1" >/dev/null 2>&1 & ;;
 	*)
 		if [ -f "$1" ]; then "$TERMINAL" -e "$EDITOR $1"
-		else setsid "$BROWSER" "$1" >/dev/null 2>&1 & fi ;;
+		else setsid $BROWSER "$1" >/dev/null 2>&1 & fi ;;
 esac


### PR DESCRIPTION
I do not understand why this is the case but removing the double quotes from the `$BROWSER` argument to successfully open.