### PR TITLE
start i3 only once after the computer is started

### DIFF
--- a/.profile
+++ b/.profile
@@ -31,7 +31,7 @@ mpd >/dev/null 2>&1 &
 echo "$0" | grep "bash$" >/dev/null && [ -f ~/.bashrc ] && source "$HOME/.bashrc"
 
 # Start graphical server if i3 not already running.
-[ "$(tty)" = "/dev/tty1" ] && ! pgrep -x i3 >/dev/null && exec startx
+[ "$(tty)" = "/dev/tty1" ] && ! pgrep -x i3 >/dev/null && [ ! -e /tmp/i3startedonce ] && touch /tmp/i3startedonce && exec startx
 
 # Switch escape and caps if tty:
 sudo -n loadkeys ~/.local/bin/ttymaps.kmap 2>/dev/null


### PR DESCRIPTION
if the user exited i3 and logged out then logged in, it's up to the user to start i3 again.
This prevent a weird behavior where i want to stop the gui and work in the tty1(when debugging the dot files) but every time i log out and in again the shell starts the gui automatically. 
the /tmp/i3startedonce will be deleted on reboot so the next boot the i3wm will start automatically