### PR TITLE
Fix typo in newsboat config

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -37,4 +37,4 @@ macro a set browser "tsp youtube-dl --add-metadata -xic -f bestaudio/best"; open
 macro v set browser "setsid nohup mpv"; open-in-browser ; set browser linkhandler
 macro w set browser "w3m"; open-in-browser ; set browser linkhandler
 macro p set browser "dmenuhandler"; open-in-browser ; set browser linkhandler
-macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkandler
+macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkhandler


### PR DESCRIPTION
This was fixed for the `archi3` branch in dcd68da.