### PR TITLE
dwmbar changes to icon layout 

### DIFF
--- a/.local/bin/dwmbar
+++ b/.local/bin/dwmbar
@@ -50,7 +50,7 @@ status() { \
 	# Show unread mail if mutt-wizard is installed.
 	command -v mw >/dev/null 2>&1 &&
 		echo "$delim" &&
-		du -a ~/.local/share/mail/*/INBOX/new/* 2>/dev/null | wc -l | sed 's/^/:/'
+		du -a ~/.local/share/mail/*/INBOX/new/* 2>/dev/null | wc -l | sed 's/^/ /'
 		echo "$delim"
 
 	# Will show all batteries with approximate icon for remaining power.

--- a/.local/bin/dwmbar
+++ b/.local/bin/dwmbar
@@ -39,7 +39,7 @@ status() { \
 
 	# Get the volume of ALSA's master volume output.  Show an icon if or
 	# not muted.
-	amixer get Master | grep -o "[0-9]*%\|\[on\]\|\[off\]" | sed "s/\[on\]//;s/\[off\]//"
+	amixer get Master | grep -o "[0-9]*%\|\[on\]\|\[off\]" | sed "s/\[on\]//;s/\[off\]//"
 
 	echo "$delim"
 

--- a/.local/bin/dwmbar
+++ b/.local/bin/dwmbar
@@ -39,7 +39,7 @@ status() { \
 
 	# Get the volume of ALSA's master volume output.  Show an icon if or
 	# not muted.
-	amixer get Master | grep -o "[0-9]*%\|\[on\]\|\[off\]" | sed "s/\[on\]//;s/\[off\]//"
+	amixer get Master | grep -o "[0-9]*%\|\[on\]\|\[off\]" | tr '\n' ' ' | sed -e '/off/c' -e 's/\[on\]//' | awk '{print $2 " " $1}' | xargs
 
 	echo "$delim"
 


### PR DESCRIPTION
Semantic changes to the `dwmbar` output
* Muted icon when output is muted
* Icon now displays on the left of the icon, matching other bar elements
* Stereo speakers do not cause 2 sets of icons
* If output is muted, only the mute icon is displayed
* Removed colon from the `mw` output 

My `amixer get Master` command returns a Front Left and Front Right, presumably due to stereo, this meant that I had duplicated output information in the bar. While fixing this could be done trivially with by piping into `head -n 2` I wanted to reverse the icon and volume so it matches other elements on the bar (and looks like the i3 status) which can be achieved with `tac`. Although this still leaves the volume number when you have your output muted.

To remedy this, the line can be flattened in order to use `sed` clear, then `awk` to swap the output's around, finally `xargs` to remove the whitespace in the event output is muted.