### PR TITLE
Fix i3blocks torrent icon

### DIFF
--- a/.local/bin/statusbar/torrent
+++ b/.local/bin/statusbar/torrent
@@ -14,7 +14,7 @@ transmission-remote -l | grep % |
 				s/L/🔼/g;
 				s/M/🔽/g;
 				s/N/✅/g;
-				s/Z/🌱/g" | awk '{print $2, $1}' | tr '\n' ' ' | sed -e "s/ $//g"
+				s/Z/🌱/g" | awk '{print $2, $1}' | sed -e "s/ $//g"
 
 case $BLOCK_BUTTON in
     1) $TERMINAL -e transmission-remote-cli ;;


### PR DESCRIPTION
Eliminate the newline so the torrent icon will show in the latest i3blocks.