### PR TITLE
fix to newsboat config and additions to init.vim

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -21,7 +21,6 @@ bind-key N prev-unread
 bind-key D pb-download
 bind-key U show-urls
 bind-key x pb-delete
-bind-key ^t next-unread
 
 color listnormal cyan default
 color listfocus black yellow standout bold

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -4,6 +4,7 @@ if ! filereadable(expand('~/.config/nvim/autoload/plug.vim'))
 	echo "Downloading junegunn/vim-plug to manage plugins..."
 	silent !mkdir -p ~/.config/nvim/autoload/
 	silent !curl "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim" > ~/.config/nvim/autoload/plug.vim
+	autocmd VimEnter * PlugInstall
 endif
 
 call plug#begin('~/.config/nvim/plugged')

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -113,6 +113,9 @@ set clipboard+=unnamedplus
 	vnoremap <leader><leader> <Esc>/<++><Enter>"_c4l
 	map <leader><leader> <Esc>/<++><Enter>"_c4l
 
+" Save file as sudo on files that require root permission
+	cnoremap w!! execute 'silent! write !sudo tee % >/dev/null' <bar> edit!
+
 """LATEX
 	" Word count:
 	autocmd FileType tex map <leader>w :w !detex \| wc -w<CR>


### PR DESCRIPTION
removed duplicate keybinding in newsboad for next-unread command
added a command to install plugins on first run
added a command to write the nvim file buffer as sudo on files that require root privileges with the w!! command