### PR TITLE
moved vikwiki keybinding from i3 config to sxhkd

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -102,8 +102,6 @@ bindsym $mod+Shift+z		gaps outer current minus 5
 
 bindsym $mod+c			exec --no-startup-id cabl
 
-bindsym $mod+v			exec --no-startup-id $term -e $EDITOR -c "VimwikiIndex"
-
 bindsym $mod+b			bar mode toggle
 bindsym $mod+Shift+b		floating toggle; sticky toggle; exec --no-startup-id hover left
 

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -15,6 +15,8 @@ super + i
 	$TERMINAL -e htop
 super + y
 	$TERMINAL -e calcurse -D ~/.config/calcurse
+super + v
+	$TERMINAL -e $EDITOR -c VimwikiIndex
 super + shift + a
 	$TERMINAL -e pulsemixer; pkill -RTMIN+10 i3blocks
 super + shift + c


### PR DESCRIPTION
moved vikwiki keybinding from i3 config to sxhkd because it's not a i3 wm command or related to i3