### PR TITLE
Remove `exec` from `startx` in `~/.profile`

### DIFF
--- a/.profile
+++ b/.profile
@@ -31,7 +31,7 @@ mpd >/dev/null 2>&1 &
 echo "$0" | grep "bash$" >/dev/null && [ -f ~/.bashrc ] && source "$HOME/.bashrc"
 
 # Start graphical server if i3 not already running.
-[ "$(tty)" = "/dev/tty1" ] && ! pgrep -x i3 >/dev/null && exec startx
+[ "$(tty)" = "/dev/tty1" ] && ! pgrep -x i3 >/dev/null && startx
 
 # Switch escape and caps if tty:
 sudo -n loadkeys ~/.local/bin/ttymaps.kmap 2>/dev/null


### PR DESCRIPTION
https://wiki.archlinux.org/index.php/Xinit#Autostart_X_at_login

> If you would like to remain logged in when the X session ends, remove exec.

I found this useful for myself - if the `X` server fails to start,
I'd get thrown out of my session (obviously, because `exec` is used).

This meant that I had to use another user which does not use the `X` server
for troubleshooting. For me, `root` worked, but you might not have access to it,
and this could help.

I don't know if this makes the setup any less secure;
if it does - lemme know.