### PR TITLE
tmux bind for new window

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -37,6 +37,7 @@ bind-key -n C-left prev
 bind-key -n C-right next
 bind-key -n C-down next
 set-window-option -g window-status-current-style bg=red
+bind C-c new-window
 bind C-j previous-window
 bind C-k next-window
 #bind-key C-a last-window # C-a C-a for last active window


### PR DESCRIPTION
I noticed there was no bind to create a new window in tmux

Edit: The default to open a new window is `Prefix + c` but that is assigned to `split-window -v`. Also `Prefix + C-c` is for a new session by default so I guess `Prefix + C-n` could also be a good candidate