### PR TITLE
Add ntfs mounting support

### DIFF
--- a/.local/bin/dmenumount
+++ b/.local/bin/dmenumount
@@ -23,6 +23,7 @@ mountusb() { \
 	partitiontype="$(lsblk -no "fstype" "$chosen")"
 	case "$partitiontype" in
 		"vfat") sudo -A mount -t vfat "$chosen" "$mp" -o rw,umask=0000;;
+		"ntfs") sudo -A ntfs-3g "$chosen" "$mp" -o rw,umask=0000;;
 		*) sudo -A mount "$chosen" "$mp"; user="$(whoami)"; ug="$(groups | awk '{print $1}')"; sudo -A chown "$user":"$ug" "$mp";;
 	esac
 	notify-send "💻 USB mounting" "$chosen mounted to $mp."


### PR DESCRIPTION
Additional support for mounting ntfs filesystem drives. Would require adding ntfs-3g to dependencies though I'm not sure where such a list is in LARBS.