### PR TITLE
Improve and more efficient RMarkdown Compilation

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -26,7 +26,7 @@ case "$file" in
 	*\.ms) refer -PS -e "$file" | groff -me -ms -kept -T pdf > "$base".pdf ;;
 	*\.mom) refer -PS -e "$file" | groff -mom -kept -T pdf > "$base".pdf ;;
 	*\.[0-9]) refer -PS -e "$file" | groff -mandoc -T pdf > "$base".pdf ;;
-	*\.rmd) echo "require(rmarkdown); render('$file')" | R -q --vanilla ;;
+	*\.rmd) echo "require(rmarkdown); rmarkdown::render('$file', quiet=TRUE)" | R -q --vanilla ;;
 	*\.tex) textype "$file" ;;
 	*\.md) pandoc "$file" --pdf-engine=xelatex -o "$base".pdf ;;
 	*config.h) sudo make install ;;


### PR DESCRIPTION
The `rmarkdown::` portion makes sure that no other functions mask render, and its calling it from the required **rmarkdown** package, and the addition of the quiet portion isnt redundant with the `R -q` flag, i tested script and in Vim it reduces how much text and verbose messaging comes from pandoc at the bottom to about 3 lines.