### PR TITLE
some small updates

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -35,8 +35,6 @@ bar {
 }
 
 # #---Basic Bindings---# #
-bindsym $mod+Shift+Return	exec --no-startup-id samedir
-
 bindsym $mod+Shift+space 	floating toggle
 bindsym $mod+space		focus mode_toggle
 

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -100,8 +100,6 @@ bindsym $mod+Ctrl+l		move workspace to output right
 bindsym $mod+z			gaps outer current plus 5
 bindsym $mod+Shift+z		gaps outer current minus 5
 
-bindsym $mod+c			exec --no-startup-id cabl
-
 bindsym $mod+b			bar mode toggle
 bindsym $mod+Shift+b		floating toggle; sticky toggle; exec --no-startup-id hover left
 

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -102,8 +102,6 @@ bindsym $mod+Shift+z		gaps outer current minus 5
 
 bindsym $mod+c			exec --no-startup-id cabl
 
-bindsym $mod+v			exec --no-startup-id $term -e $EDITOR -c "VimwikiIndex"
-
 bindsym $mod+b			bar mode toggle
 bindsym $mod+Shift+b		floating toggle; sticky toggle; exec --no-startup-id hover left
 

--- a/.config/mpd/mpd.conf
+++ b/.config/mpd/mpd.conf
@@ -13,8 +13,8 @@ restore_paused "yes"
 max_output_buffer_size "16384"
 
 audio_output {
-      type  "pulse"
-      name  "pulse audio"
+      type  "alsa"
+      name  "alsa for audio soundcard"
       mixer_type "software"
 }
 

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -109,3 +109,8 @@ set clipboard+=unnamedplus
 	autocmd BufWritePost *Xresources,*Xdefaults !xrdb %
 " Update binds when sxhkdrc is updated.
 	autocmd BufWritePost *sxhkdrc !pkill -USR1 sxhkd
+
+" Turns off highlighting on the bits of code that are changed, so the line that is changed is highlighted but the actual text that has changed stands out on the line and is readable.
+if &diff
+    highlight! link DiffText MatchParen
+endif

--- a/.config/ranger/rc.conf
+++ b/.config/ranger/rc.conf
@@ -457,7 +457,7 @@ map cW bulkrename %s
 map mkd console mkdir%space
 map sc console shell ln -sT%space
 map D console delete
-map X shell extract %f
+map X shell atool -x %f
 map Z shell tar -cvzf %f.tar.gz %s
 map <C-f> fzf_select
 map <C-l> fzf_locate

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -25,7 +25,7 @@ super + n
 super + c
 	$TERMINAL -e calcurse -D ~/.config/calcurse
 super + v
-	$TERMINAL -e nvim -c VimwikiIndex
+	$TERMINAL -c VimwikiIndex -e nvim
 super + shift + a
 	$TERMINAL -e alsamixer; pkill -RTMIN+10 $STATUSBAR
 super + shift + c

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -10,6 +10,8 @@
 # Basic binds
 super + Return
 	$TERMINAL
+super + shift + Return
+	samedir
 super + shift + q
 	kill -9 `xdotool getwindowfocus getwindowpid`
 super + d


### PR DESCRIPTION
removed double keybindings between i3 config and sxhkd, and non existent script keybindings from i3 config
moved samedir keybinding to sxhkd so that it can be used on any wm
changed output of mpd.conf to alsa since LARBS now comes with alsa only
fixed class of Vimwikiindex
changed rangers rc.conf to use atool for archive extraction instead of extract script (which seems to be non existent or renamed)
added a nice vimdiff highlighting setting to init.vim so that lines that are changed are highlighted, but the text is actually readable as it now stands out in the line