### PR TITLE
Revert "class needs to be set before the command otherwise it's not s…

### DIFF
--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -27,7 +27,7 @@ super + n
 super + c
 	$TERMINAL -e calcurse -D ~/.config/calcurse
 super + v
-	$TERMINAL -c VimwikiIndex -e nvim
+	$TERMINAL -e nvim -c VimwikiIndex
 super + shift + a
 	$TERMINAL -e alsamixer; pkill -RTMIN+10 $STATUSBAR
 super + shift + c


### PR DESCRIPTION
…et at all"

This reverts commit bf5b003d

This is a mistake. It's not class but command to Nvim. And It breaks the intended feature.