### PR TITLE
fix(i3 config)

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -39,7 +39,6 @@ bindsym $mod+Shift+space 	floating toggle
 bindsym $mod+space		focus mode_toggle
 
 bindsym $mod+Escape		workspace prev
-bindsym $mod+Shift+Escape 	exec --no-startup-id prompt "Exit i3?" "i3-msg exit"
 
 #STOP/HIDE EVERYTHING:
 bindsym $mod+Shift+Delete	exec --no-startup-id lmc truemute ; exec --no-startup-id lmc pause ; exec --no-startup-id pauseallmpv; workspace 0; exec $term -e htop ; exec $term -e $FILE


### PR DESCRIPTION
Removed redundant keyboard shortcut that can be found in the sxhkdrc config