### PR TITLE
corrected file extension error with Rmd produced pdf's opening with opout

### DIFF
--- a/.local/bin/opout
+++ b/.local/bin/opout
@@ -7,7 +7,7 @@
 basename="$(echo "$1" | sed 's/\.[^\/.]*$//')"
 
 case "$1" in
-	*.tex|*.md|*.rmd|*.ms|*.me|*.mom) setsid "$READER" "$basename".pdf >/dev/null 2>&1 & ;;
+	*.tex|*.md|*.Rmd|*.rmd|*.ms|*.me|*.mom) setsid "$READER" "$basename".pdf >/dev/null 2>&1 & ;;
 	*.[0-9]) setsid "$READER" "$basename".pdf >/dev/null 2>&1 & ;;
 	*.html) setsid $BROWSER "$basename".html >/dev/null 2>&1 & ;;
 	*.sent) setsid sent "$1" >/dev/null 2>&1 & ;;


### PR DESCRIPTION
casing is sensitive on the rmd/Rmd files, without the uppercase option opout was not functioning for me on default LARBS with thinkpad x220. 

tested on home system and verified that functionality as intended is achieved with the `*.Rmd` option is added to the case statement