### PR TITLE
Replace absolute path in .xprofile

### DIFF
--- a/.xprofile
+++ b/.xprofile
@@ -12,4 +12,4 @@ sxhkd -m 1 &		# Bind keys with sxhkd
 xset r rate 300 50 &	# Speed xrate up
 unclutter &		# Remove mouse when idle
 mpd-module-update &	# Check for when to update the mpd module
-notify-send -i /home/luke/.local/share/larbs/larbs.png "Welcome to LARBS" "Press super+F1 for the help menu." # LARBSWELCOME
+notify-send -i ~/.local/share/larbs/larbs.png "Welcome to LARBS" "Press super+F1 for the help menu." # LARBSWELCOME


### PR DESCRIPTION
The `.xprofile` file currently uses an absolute path for the LARBS picture in the `notify-send` command, which obviously won't work unless your name is Luke. This pull request will fix this issue.