### PR TITLE
KBLayoutManager now aids multi-layout keyboards.

### DIFF
--- a/.config/i3blocks/config
+++ b/.config/i3blocks/config
@@ -50,6 +50,10 @@ signal=12
 interval=once
 signal=10
 
+[lang]
+interval=once
+signal=13
+
 #[disk]
 #interval=60
 #command=disk /

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -38,6 +38,8 @@ super + w
 	$TERMINAL -e sudo nmtui
 super + shift + w
 	$BROWSER
+super + space
+	kblayoutmanager cycle $(echo $KBLAYOUTS)
 
 # Et cetera...
 super + grave

--- a/.local/bin/kblayoutmanager
+++ b/.local/bin/kblayoutmanager
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# An adaptation of https://github.com/porras/i3-keyboard-layout/blob/master/i3-keyboard-layout by MYDavoodeh
+set -e
+
+get_kbdlayout() { setxkbmap -query | grep -oP 'layout:\s*\K(\w+)' ;}
+
+set_kbdlayout() {
+	# FIXME what to do for variants?
+	setxkbmap "$1"
+	pgrep i3status | xargs --no-run-if-empty kill -s USR1 # to tell i3status to update
+}
+
+cycle() { #TODO: Optimize cycling time
+	current_layout=$(get_kbdlayout)
+	eval last="\$$#"
+	# If current_layout is the last one OR current_layout is not in the given layouts, set the first one in cycle as the initiator. Else find the next.
+	{ [ "$last" = "$current_layout" ] || ! echo "$*" | grep -qo "$current_layout" ;} && set_kbdlayout "$1" || set_kbdlayout "$(echo "$*" | cut -d' ' -f "$#")"
+}
+
+
+subcommand="$1"
+helpmsg="Please specify one of: get, set <layout> or cycle <layout1> <layout2> ... <layoutN>"
+
+shift || (echo "$helpmsg" && exit)
+case $subcommand in
+	"get") echo get_kbdlayout ;;
+	"set") set_kbdlayout "$1" ;;
+	"cycle") cycle "$@" ;;
+	*) echo "Fatal: Command $subcommand not found.\n$helpmsg" ;;
+esac
+
+pkill -RTMIN+13 i3blocks # for [lang] in i3blocks

--- a/.local/bin/statusbar/lang
+++ b/.local/bin/statusbar/lang
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# A simple module to print current KBLAYOUT
+# Works best with my script of KBLayoutManager.
+# This script sends the update signal and it is bound in i3/config.
+lang=$(setxkbmap -print | grep xkb_symbols | awk '{print $4}' | awk -F"+" '{print $2}')
+[ "$lang" = "us" ] && color="#00ff00" || color="#ff0000" # This line is added to add awareness and ease to detect the us layout in a glance to be ascertain that your shortcuts and keystrokes will remain responsive # FIXME don't be coloured for us variations
+printf "<span color='%s'>%s</span>\n" "$color" "$lang"

--- a/.profile
+++ b/.profile
@@ -26,6 +26,7 @@ export ZDOTDIR="$HOME/.config/zsh"
 export PASSWORD_STORE_DIR="$HOME/.local/share/password-store"
 
 # Other program settings:
+export KBLAYOUTS="us ir"
 export DICS="/usr/share/stardict/dic/"
 export SUDO_ASKPASS="$HOME/.local/bin/dmenupass"
 export FZF_DEFAULT_OPTS="--layout=reverse --height 40%"


### PR DESCRIPTION
It has numerous problems for the moment (such as slow switching and no variation support) but I think it's a necessary feature for a desktop to have.

`$KBLAYOUTS` holds the list of languages to cycle through.
The value of it must be space separated.

As an example I'm using Farsi/Persian (ir).