### PR TITLE
tramsmission-remote-cli discontinued, using python3 fork tremc

### DIFF
--- a/.local/bin/torwrap
+++ b/.local/bin/torwrap
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-ifinstalled transmission-remote-cli transmission-cli || exit
+ifinstalled tremc transmission-cli || exit
 
 ! pgrep -x transmission-da >/dev/null && transmission-daemon && notify-send "Starting torrent daemon..." && sleep 3 && pkill -RTMIN+7 "${STATUSBAR:?}"
 
-$TERMINAL -e transmission-remote-cli
+$TERMINAL -e tremc


### PR DESCRIPTION
referencing issue #512 
this would implement the newer, continued python3 version