### PR TITLE
Add option for an additional battery block

### DIFF
--- a/.config/i3blocks/config
+++ b/.config/i3blocks/config
@@ -59,6 +59,11 @@ signal=10
 command=battery BAT0
 interval=5
 
+# Uncomment for Battery if using thinkpad slice battery
+#[battery]
+#command=battery BAT1
+#interval=5
+
 [clock]
 label=📅
 interval=30


### PR DESCRIPTION
if users have a thinkpad with a slice battery this will let them see both batteries using the same block script in their status bar 