### PR TITLE
tool for opening scripts shorter and etc

### DIFF
--- a/.local/bin/dcf
+++ b/.local/bin/dcf
@@ -1,0 +1,31 @@
+#!/bin/sh
+# IT CAN TAKE ONLY ONE FLAG
+# example:  " dcf h -33 <command> " or " dcf c -n <command>"
+
+one="$1" ; two="$2" ; three="$3" ; four="$4"
+
+#If no function is used, work as "which"
+[ -z "$two" ] && which $one && break && exit
+
+#Shift values, if there is no flag
+[ -z "$three" ] && three="$two" && two=""
+
+# Tells you which package owns that command,
+p() { pacman "${two:--Qo}" $( which "$three" ) ; }
+# or give it a file directly (for lib or share, which aren't executable)
+pl() { pacman "${two:--Qo}" $( echo "$three" ) ; }
+
+# Print || read || modify that script
+c() { cat  $two $( which "$three" ) ; }
+l() { less $two $( which "$three" ) ; }
+v() { nvim $two $( which "$three" ) ; }
+h() { head $two $( which "$three" ) ; }
+t() { tail $two $( which "$three" ) ; }
+
+#grep has 1 argument more, shift again.
+g() { [ -z "$four" ] && four="$three" && three="$two" && two="" ;
+	grep --color=auto $two "$three" $( which "$four" ) ; }
+
+$1
+
+#pro-tip: alias "dcf v" to "dcfv" to immediately open a script in vim.


### PR DESCRIPTION
No need to find your script and then open them. This opens your script automatically, by finding its absolute path. It is not limited to local scripts, just make sure it is not a binary.
If it is a binary exec, it can find out which package owns it, and If it isnt a exec, (lib or share) give its full path. Examples:
$ dcf p i3            # this will tell you that "i3-gaps" owns the file "/usr/bin/i3"
$ dcf pl /usr/lib/pkgconfig/zathura.pc    # tells you that its owned by zathura
$ dcf v setbg    # this will open ~/.local/bin/setbg in nvim
$ dcf c -n lmc     # prints out ~/.local/bin/lmc with numbered lines
$ dcf h -15 shortcuts    # prints the first 15 lines of ~/.local/bin/shortcuts
$ dcf t -1 setbg   # prints the last line of ~/.local/bin/setbg
$ dcf l -S volume  # less -S ~/.local/bin/statusbar/volume
$ dcf g -i home weather   # case insensitively grep home from the script weather
$ dcf weather     # works as 'which', only tells you the location of that command

The name stands for "Do command file", but if you have a better one, change it.