### PR TITLE
for partial XDG supporting apps

### DIFF
--- a/.config/user-dirs.dirs
+++ b/.config/user-dirs.dirs
@@ -1,1 +1,3 @@
 XDG_DESKTOP_DIR="$HOME/"
+XDG_CONFIG_HOME="$HOME/.config"
+XDG_DATA_HOME="$HOME/.local/share"


### PR DESCRIPTION
calcurse keeps creating new configs at ~/ without these two lines