### PR TITLE
sxiv: Prevent writing all marked imgs onto file (lossage)

### DIFF
--- a/.config/sxiv/exec/key-handler
+++ b/.config/sxiv/exec/key-handler
@@ -6,11 +6,13 @@ do
         "c")
 		[ -z "$destdir" ] && destdir="$(sed "s/\s.*#.*$//;/^\s*$/d" ~/.config/directories | awk '{print $2}' | dmenu -l 20 -i -p "Copy file(s) to where?" | sed "s|~|$HOME|g")"
 		[ -z "$destdir" ] && exit
+		[ ! -d "$destdir" ] && notify-send "$destdir is not a directory, cancelled." && exit
 		cp "$file" "$destdir" && notify-send -i "$(readlink -f "$file")" "$file copied to $destdir." &
 		;;
         "m")
 		[ -z "$destdir" ] && destdir="$(sed "s/\s.*#.*$//;/^\s*$/d" ~/.config/directories | awk '{print $2}' | dmenu -l 20 -i -p "Move file(s) to where?" | sed "s|~|$HOME|g")"
 		[ -z "$destdir" ] && exit
+		[ ! -d "$destdir" ] && notify-send "$destdir is not a directory, cancelled." && exit
 		mv "$file" "$destdir" && notify-send -i "$(readlink -f "$file")" "$file moved to $destdir." &
 		;;
 	"r")


### PR DESCRIPTION
Running `C-x c` `copy` or `C-x m` `move` will copy/move all the marked files to a
single location. If that location is not a directory, then creating that file
and overwriting it several times results in complete loss of data in the case of
moving, and unhelpful behaviour in the case of "copying". Only the last marked
file remains in the file.

This fix only moves/copies the first marked file, then issues a warning message.

![sxiv-script-warnage](https://user-images.githubusercontent.com/13551856/78203833-dea65280-744c-11ea-9cf0-3c3e05496380.png)
(My StumpWM gentoo linux system, and a Brazilian cat)

P.S. Send me pictures of your cat if reading this, thank you.