### PR TITLE
New feature: Zsh named dirs

### DIFF
--- a/.config/aliasrc
+++ b/.config/aliasrc
@@ -42,5 +42,5 @@ alias mpv="mpv --input-ipc-server=/tmp/mpvsoc$(date +%s)"
 # Some other stuff
 alias \
 	magit="nvim -c MagitOnly" \
-	ref="shortcuts >/dev/null; source ~/.config/shortcutrc" \
+	ref="shortcuts >/dev/null; source ~/.config/shortcutrc; source ~/.config/zshnameddirrc" \
 	weath="less -S ~/.local/share/weatherreport" \

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -3,9 +3,10 @@
 autoload -U colors && colors
 PS1="%B%{$fg[red]%}[%{$fg[yellow]%}%n%{$fg[green]%}@%{$fg[blue]%}%M %{$fg[magenta]%}%~%{$fg[red]%}]%{$reset_color%}$%b "
 
-# Load aliases and shortcuts if existent.
+# Load aliases, shortcuts and nameddirs if existent.
 [ -f "$HOME/.config/shortcutrc" ] && source "$HOME/.config/shortcutrc"
 [ -f "$HOME/.config/aliasrc" ] && source "$HOME/.config/aliasrc"
+[ -f "$HOME/.config/zshnameddirrc" ] && source "$HOME/.config/zshnameddirrc"
 
 autoload -U compinit
 zstyle ':completion:*' menu select

--- a/.local/bin/shortcuts
+++ b/.local/bin/shortcuts
@@ -2,19 +2,21 @@
 
 # Output locations. Unactivated progs should go to /dev/null.
 shell_shortcuts="$HOME/.config/shortcutrc"
+zsh_named_dirs="$HOME/.config/zshnameddirrc"
 ranger_shortcuts="$HOME/.config/ranger/shortcuts.conf"
 qute_shortcuts="/dev/null"
 fish_shortcuts="/dev/null"
 vifm_shortcuts="$HOME/.config/vifm/vifmshortcuts"
 
 # Remove, prepare files
-rm -f "$ranger_shortcuts" "$qute_shortcuts" 2>/dev/null
+rm -f "$ranger_shortcuts" "$qute_shortcuts" "$zsh_named_dirs" 2>/dev/null
 printf "# vim: filetype=sh\\n" > "$fish_shortcuts"
 printf "# vim: filetype=sh\\nalias " > "$shell_shortcuts"
 printf "\" vim: filetype=vim\\n" > "$vifm_shortcuts"
 
 # Format the `directories` file in the correct syntax and sent it to all three configs.
 sed "s/\s*#.*$//;/^\s*$/d" "$HOME/.config/directories" | tee >(awk '{print $1"=\"cd "$2" && ls -a\" \\"}' >> "$shell_shortcuts") \
+	>(awk '{print "hash -d "$1"="$2}' >> "$zsh_named_dirs") \
 	>(awk '{print "abbr", $1, "\"cd " $2 "; and ls -a\""}' >> "$fish_shortcuts") \
 	>(awk '{print "map g" $1, ":cd", $2 "<CR>\nmap t" $1, "<tab>:cd", $2 "<CR><tab>\nmap M" $1, "<tab>:cd", $2 "<CR><tab>:mo<CR>\nmap Y" $1, "<tab>:cd", $2 "<CR><tab>:co<CR>" }' >> "$vifm_shortcuts") \
 	>(awk '{print "config.bind(\";"$1"\", \"set downloads.location.directory "$2" ;; hint links download\")"}' >> "$qute_shortcuts") \


### PR DESCRIPTION
I think this is useful. It uses the same directory shortcut file (~/.config/directories)

You can do things like this from Zsh shell:
`$ mv file.tex ~d`
Or even better and more relevant example:
`$ rsync ~d/file.tex ~D/project.tar user@server:~/`

The main idea is the user doesn't have to write the entire path when using Zsh shell only.
They can use any binding from the directory shortcut file.

Filename completion works too when using this.