### PR TITLE
wttr options

### DIFF
--- a/.local/bin/statusbar/weather
+++ b/.local/bin/statusbar/weather
@@ -7,14 +7,14 @@
 # You could set up a shell alias to view the full file in a pager in the
 # terminal if desired. This function will only be run once a day when needed.
 getforecast() { ping -q -c 1 1.1.1.1 >/dev/null &&
-curl -sf "wttr.in/$LOCATION" > "$HOME/.local/share/weatherreport" || exit 1 ;}
+curl -sf "wttr.in/${LOCATION}?1FQT" > "$HOME/.local/share/weatherreport" || exit 1 ;}
 
 # Some very particular and terse stream manipulation. We get the maximum
 # precipication chance and the daily high and low from the downloaded file and
 # display them with coresponding emojis.
-showweather() { printf "%s" "$(sed '16q;d' "$HOME/.local/share/weatherreport" |
+showweather() { printf "%s" "$(sed '14q;d' "$HOME/.local/share/weatherreport" |
 	grep -wo "[0-9]*%" | sort -rn | sed "s/^/☔ /g;1q" | tr -d '\n')"
-sed '13q;d' "$HOME/.local/share/weatherreport" | grep -o "m\\([-+]\\)*[0-9]\\+" | sort -n -t 'm' -k 2n | sed -e 1b -e '$!d' | tr '\n|m' ' ' | awk '{print " ❄️",$1 "°","🌞",$2 "°"}' ;}
+sed '11q;d' "$HOME/.local/share/weatherreport" | grep -o "\\([-+]\\)*[0-9]\\+" | sort -n | sed -e 1b -e '$!d' | tr '\n' ' ' | awk '{print " ❄️",$1 "°","🌞",$2 "°"}' ;}
 
 # The BLOCK_BUTTON bloat for clicking in i3.
 case $BLOCK_BUTTON in


### PR DESCRIPTION
This adds options to the wttr link that basically remove bloat that the module does not need, making parsing the file easier.
The options are listed [here](https://wttr.in/:help). 

The ones added here are:
1 -- only get the current day report
F -- do not show the "Follow" line
Q -- superquiet version (no "Weather report", no city name)
T -- switch terminal sequences off (no colors)
