### PR TITLE
Move bg link to ~/.local/share/

### DIFF
--- a/.cache/bg
+++ b/.cache/bg
@@ -1,1 +1,0 @@
-../.config/wall.png

--- a/.local/bin/setbg
+++ b/.local/bin/setbg
@@ -7,7 +7,7 @@
 #	If wal is installed, also generate a colorscheme.
 
 # Location of link to wallpaper link.
-bgloc="${XDG_CACHE_HOME:-$HOME/.cache/}/bg"
+bgloc="${XDG_DATA_HOME:-$HOME/.local/share/}/bg"
 
 [ -f "$1" ] && ln -sf "$(readlink -f "$1")" "$bgloc" && notify-send -i "$bgloc" "Changing wallpaper..."
 

--- a/.local/share/bg
+++ b/.local/share/bg
@@ -1,0 +1,1 @@
+../../.config/wall.png


### PR DESCRIPTION
often the ~/.cache directory is deleted because it gets too big, in my case if i compile stuff with yay, firefoxs cache also gets quite big, and mesa shaders are also stored there.