### PR TITLE
fix: Use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".config/mpv/scripts/mpvSockets"]
 	path = .config/mpv/scripts/mpvSockets
-	url = git@github.com:wis/mpvSockets.git
+	url = https://github.com/wis/mpvSockets.git


### PR DESCRIPTION
Use HTTPS instead of SSH, so that users without a GitHub account can still clone the submodule.