### PR TITLE
chore: Use $XDG_CONFIG_HOME in lfrc

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -2,13 +2,15 @@
 
 # Basic vars
 set shell bash
-set previewer ~/.config/lf/scope
 set shellopts '-eu'
 set ifs "\n"
 set scrolloff 10
 set color256
 set icons
 set period 1
+
+# Vars that depend on environmental variables
+$lf -remote "send $id set previewer ${XDG_CONFIG_HOME:-$HOME/.config}/lf/scope"
 
 # cmds/functions
 cmd open ${{


### PR DESCRIPTION
Need to send the commands in shell scope to `lf` in order to use environmental variables in `lfrc` file. We can utilize this method to use `$XDG_CONFIG_HOME` to set path to `scope`.