### PR TITLE
fix: Properly evaluate $XDG_CONFIG_HOME in rc.conf

### DIFF
--- a/.config/ranger/rc.conf
+++ b/.config/ranger/rc.conf
@@ -5,7 +5,6 @@ set column_ratios 1,3,4
 set hidden_filter ^\.|\.(?:pyc|vrb|pyo|lof|bak|swp|aux|log|nav|out|snm|toc|bcf|run\.xml|synctex\.gz|blg|bbl)$|^lost\+found$|^__(py)?cache__$
 set show_hidden false
 set confirm_on_delete multiple
-set preview_script ${XDG_CONFIG_HOME:-$HOME/.config}/ranger/scope.sh
 set use_preview_script true
 set automatically_count_files true
 set open_all_images true
@@ -505,4 +504,5 @@ map Tn eval fm.open_console('shell eyeD3 -n "" ' + fm.thisfile.relative_path, po
 #Downloading
 map ytv console shell youtube-dl -ic%space
 map yta console shell youtube-dl -xic%space
-source ${XDG_CONFIG_HOME:-$HOME/.config}/ranger/shortcuts.conf
+
+eval cmd('source ' + fm.confpath('shortcuts.conf'))


### PR DESCRIPTION
By default, `ranger` supports `$XDG_CONFIG_HOME` and also provides fallback if not set. Thus the default path for `scope.sh` is in accordance with **LARBS** and setting `preview_script` explicitly is unnecessary.

To properly use `$XDG_CONFIG_HOME` though for `ranger` when sourcing additional files, a workaround is needed, using `fm.confpath()`.

Fixes #552.