### PR TITLE
tell Qt to use whatever the current GTK2 theme is

### DIFF
--- a/.config/xprofile
+++ b/.config/xprofile
@@ -19,3 +19,6 @@ xcompmgr &		# xcompmgr for transparency
 dunst &			# dunst for notifications
 xset r rate 300 50 &	# Speed xrate up
 unclutter &		# Remove mouse when idle
+
+# program settings:
+export QT_QPA_PLATFORMTHEME="gtk2"

--- a/.profile
+++ b/.profile
@@ -41,6 +41,7 @@ export LESS_TERMCAP_se="$(printf '%b' '[0m')"
 export LESS_TERMCAP_us="$(printf '%b' '[1;32m')"
 export LESS_TERMCAP_ue="$(printf '%b' '[0m')"
 export LESSOPEN="| /usr/bin/highlight -O ansi %s 2>/dev/null"
+export QT_QPA_PLATFORMTHEME="gtk2"
 
 # This is the list for lf icons:
 export LF_ICONS="di=📁:\


### PR DESCRIPTION
Just this one change for now, but there's a couple more that I can add if you're interested in upstreaming them:
* (in `~/.config/files`) alias cfp -> `~/.profile`
* (in `xprofile`) set an environment variable to make touchscreen input work correctly on Firefox and Firefox-based browsers