### PR TITLE
hide go folder

### DIFF
--- a/.profile
+++ b/.profile
@@ -27,6 +27,7 @@ export PASSWORD_STORE_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/password-store"
 export TMUX_TMPDIR="$XDG_RUNTIME_DIR"
 export ANDROID_SDK_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/android"
 export CARGO_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/cargo"
+export GOPATH="${XDG_DATA_HOME:-$HOME/.local/share}/go"
 
 # Other program settings:
 export DICS="/usr/share/stardict/dic/"


### PR DESCRIPTION
go folder is the go language workspace and is placed in your home directory by default. even if you don't use go, it will be created in process of building something written in go. this moves go folder to .local/share/go.

i'm not writing in go, maybe there is a point of keeping this folder in your home directory, but i don't really see it.