### PR TITLE
Added OpenSCAD run conditions to compiler script

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -33,6 +33,7 @@ case "$file" in
         *\.c) cc "$file" -o "$base" && "$base" ;;
 	*\.py) python "$file" ;;
 	*\.m) octave "$file" ;;
+	*\.scad) openscad -o "$base".stl "$file" ;;
 	*\.go) go run "$file" ;;
 	*\.sent) setsid sent "$file" 2>/dev/null & ;;
 	*) sed 1q "$file" | grep "^#!/" | sed "s/^#!//" | xargs -r -I % "$file" ;;


### PR DESCRIPTION
Default output to STL seems appropriate. STL files can be viewed with a minimalist program like fstl (in the AUR)