### PR TITLE
i3 to use slock

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -134,7 +134,7 @@ bindsym $mod+Ctrl+l		move workspace to output right
 bindsym $mod+z			gaps outer current plus 5
 bindsym $mod+Shift+z		gaps outer current minus 5
 
-bindsym $mod+x			exec --no-startup-id mpc pause; exec --no-startup-id pauseallmpv ; exec --no-startup-id i3lock -e -f -c 1d2021 ; exec --no-startup-id xset dpms force off
+bindsym $mod+x			exec --no-startup-id xset dpms force off && mpc pause && pauseallmpv && slock &
 bindsym $mod+Shift+x		exec --no-startup-id prompt "Shutdown computer?" "$shutdown"
 
 bindsym $mod+c			exec --no-startup-id cabl


### PR DESCRIPTION
it could only work with '&&' and only in this order. i see that it would be logical to "slock" even if a preceding command will fail, though like i said it would only run in this order. i've tried using a script (even in this order) with " ; " it would not run. 
the audios would mute and the screen would turn off, but it would not lock.