### PR TITLE
Upstream problem with java not able to figure dwm's windows.

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -51,6 +51,8 @@ export LESS_TERMCAP_ue="$(printf '%b' '[0m')"
 export LESSOPEN="| /usr/bin/highlight -O ansi %s 2>/dev/null"
 export QT_QPA_PLATFORMTHEME="gtk2"	# Have QT use gtk2 theme.
 export MOZ_USE_XINPUT2="1"		# Mozilla smooth scrolling/touchpads.
+export _JAVA_AWT_WM_NONREPARENTING=1.   # Java doesn't understand tiling windows 
+export AWT_TOOLKIT="MToolkit wmname LG3D"
 
 # This is the list for lf icons:
 export LF_ICONS="di=📁:\

--- a/.zprofile
+++ b/.zprofile
@@ -52,8 +52,7 @@ export LESSOPEN="| /usr/bin/highlight -O ansi %s 2>/dev/null"
 export QT_QPA_PLATFORMTHEME="gtk2"	# Have QT use gtk2 theme.
 export MOZ_USE_XINPUT2="1"		# Mozilla smooth scrolling/touchpads.
 export _JAVA_AWT_WM_NONREPARENTING=1    # Java doesn't understand tiling windows 
-export AWT_TOOLKIT="MToolkit wmname LG3D"
-
+export AWT_TOOLKIT="MToolkit wmname LG3D"  #May have to install wmname
 # This is the list for lf icons:
 export LF_ICONS="di=📁:\
 fi=📃:\

--- a/.zprofile
+++ b/.zprofile
@@ -51,7 +51,7 @@ export LESS_TERMCAP_ue="$(printf '%b' '[0m')"
 export LESSOPEN="| /usr/bin/highlight -O ansi %s 2>/dev/null"
 export QT_QPA_PLATFORMTHEME="gtk2"	# Have QT use gtk2 theme.
 export MOZ_USE_XINPUT2="1"		# Mozilla smooth scrolling/touchpads.
-export _JAVA_AWT_WM_NONREPARENTING=1.   # Java doesn't understand tiling windows 
+export _JAVA_AWT_WM_NONREPARENTING=1    # Java doesn't understand tiling windows 
 export AWT_TOOLKIT="MToolkit wmname LG3D"
 
 # This is the list for lf icons:


### PR DESCRIPTION
Jetbrains products (intellij Idea and pycharm) and Netbeans draws grey windows in dwm(upstream bug). 
Intellij Idea will work with this two env vars. for pycharm, affected plebs may need to install the wmname tool (community repository)