### PR TITLE
Placing NERDTree bookmark file not on home dir

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -51,6 +51,11 @@ set clipboard+=unnamedplus
 " Nerd tree
 	map <leader>n :NERDTreeToggle<CR>
 	autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+    if has('nvim')
+        let NERDTreeBookmarksFile = stdpath('data') . '/NERDTreeBookmarks'
+    else
+        let NERDTreeBookmarksFile = '~/.vim' . '/NERDTreeBookmarks'
+    endif
 
 " vimling:
 	nm <leader>d :call ToggleDeadKeys()<CR>


### PR DESCRIPTION
The default location in home directory.
Now placing it on nvim data directory(~/.local/share/nvim) or "~/.vim" directory in case of the good old vim.