### PR TITLE
Replace tr(1)/sed(1) combo with paste(1)

### DIFF
--- a/.local/bin/displayselect
+++ b/.local/bin/displayselect
@@ -53,7 +53,7 @@ multimon() { # Multi-monitor handler.
 	esac ;}
 
 onescreen() { # If only one output available or chosen.
-	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$1" | awk '{print "--output", $1, "--off"}' | tr '\n' ' ')
+	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ')
 	}
 
 postrun() { # Stuff to run to clean up.

--- a/.local/bin/statusbar/music
+++ b/.local/bin/statusbar/music
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | tr '\n' ' ' | sed 's/ $//' ;}
+filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | paste -sd ' ';}
 
 case $BLOCK_BUTTON in
 	1) mpc status | filter ; setsid "$TERMINAL" -e ncmpcpp & ;;  # right click, pause/unpause

--- a/.local/bin/statusbar/nettraf
+++ b/.local/bin/statusbar/nettraf
@@ -13,8 +13,8 @@ esac
 rxfile="${XDG_CACHE_HOME:-$HOME/.cache}/rxlog"
 txfile="${XDG_CACHE_HOME:-$HOME/.cache}/txlog"
 
-rxcurrent="$(cat /sys/class/net/*/statistics/rx_bytes | tr '\n' '+' | sed 's/+$/\n/' | bc)"
-txcurrent="$(cat /sys/class/net/*/statistics/tx_bytes | tr '\n' '+' | sed 's/+$/\n/' | bc)"
+rxcurrent="$(cat /sys/class/net/*/statistics/rx_bytes | paste -sd '+' | bc)"
+txcurrent="$(cat /sys/class/net/*/statistics/tx_bytes | paste -sd '+' | bc)"
 
 printf "🔻%skB 🔺%skB\\n" \
 	"$(printf -- "(%s-%s)/1024\\n" "$rxcurrent" "$(cat "$rxfile")" | bc)" \

--- a/.local/bin/statusbar/torrent
+++ b/.local/bin/statusbar/torrent
@@ -14,7 +14,7 @@ transmission-remote -l | grep % |
 				s/L/🔼/g;
 				s/M/🔽/g;
 				s/N/✅/g;
-				s/Z/🌱/g" | awk '{print $2, $1}' | tr '\n' ' ' | sed 's/ $//'
+				s/Z/🌱/g" | awk '{print $2, $1}' | paste -sd ' '
 
 case $BLOCK_BUTTON in
 	1) setsid "$TERMINAL" -e tremc & ;;

--- a/.zprofile
+++ b/.zprofile
@@ -6,7 +6,7 @@
 # to clean up.
 
 # Adds `~/.local/bin` to $PATH
-export PATH="$PATH:$(du "$HOME/.local/bin/" | cut -f2 | tr '\n' ':' | sed 's/:*$//')"
+export PATH="$PATH:$(du "$HOME/.local/bin/" | cut -f2 | paste -sd ':')"
 
 # Default programs:
 export EDITOR="nvim"


### PR DESCRIPTION
The `paste(1)` command is designed to concatenate lines of input. Several scripts used something like `tr '\n' '+' | sed 's/+$//'`. I've replaced this with a much simpler `paste -sd '+'`.