### PR TITLE
Update transadd

### DIFF
--- a/.local/bin/transadd
+++ b/.local/bin/transadd
@@ -1,4 +1,4 @@
-patch-1#!/bin/sh
+#!/bin/sh
 
 # Mimeapp script for adding torrent to transmission-daemon, but will also start the daemon first if not running.
 

--- a/.local/bin/transadd
+++ b/.local/bin/transadd
@@ -1,9 +1,9 @@
-#!/bin/sh
+patch-1#!/bin/sh
 
 # Mimeapp script for adding torrent to transmission-daemon, but will also start the daemon first if not running.
 
 # transmission-daemon sometimes fails to take remote requests in its first moments, hence the sleep.
 
-pidof transmission-daemon >/dev/null || (transmission-daemon && notify-send "Starting transmission daemon..." && sleep 3 && pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}") &
+pidof transmission-daemon >/dev/null || (transmission-daemon && notify-send "Starting transmission daemon..." && sleep 3 && pkill -RTMIN+7 "${STATUSBAR:-dwmblocks}")
 
 transmission-remote -a "$@" && notify-send "🔽 Torrent added."


### PR DESCRIPTION
Add torrent when transmission daemon isn't open.

In the original code, the user needs to "add" the torrent twice in order to add it, the first time opening transmission and again for adding the torrent

