### PR TITLE
Add keyboard layout related scripts

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -46,6 +46,7 @@ bar {
 bindsym $mod+Return 		exec $term
 bindsym $mod+Shift+Return	exec --no-startup-id samedir
 
+bindsym $mod+Mod1+space 	exec --no-startup-id kblayoutmanager cycle $(echo $KBLAYOUTS)
 bindsym $mod+Shift+space 	floating toggle
 bindsym $mod+space		focus mode_toggle
 

--- a/.config/i3blocks/config
+++ b/.config/i3blocks/config
@@ -45,6 +45,10 @@ signal=12
 interval=once
 signal=10
 
+[lang]
+interval=once
+signal=13
+
 #[disk]
 #interval=60
 #command=disk /

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -36,6 +36,8 @@ super + shift + w
 	$BROWSER
 
 # Et cetera...
+super + alt + space
+	kblayoutmanager cycle $(echo $KBLAYOUTS)
 super + grave
 	dmenuunicode
 super + Scroll_Lock

--- a/.local/bin/kblayoutmanager
+++ b/.local/bin/kblayoutmanager
@@ -1,0 +1,34 @@
+#!/bin/sh
+# An edited https://github.com/porras/i3-keyboard-layout/blob/master/i3-keyboard-layout by MYDavoodeh
+# FIXME The script is relatively way too slow (especially when cycling)
+set -e
+
+get_kbdlayout(){ setxkbmap -query | grep -oP 'layout:\s*\K\w+' ;}
+
+set_kbdlayout(){ # TODO Add support for variations of langugages
+	setxkbmap "$1"
+	# pgrep i3status | xargs --no-run-if-empty kill -s USR1 # to tell i3status to update
+}
+
+cycle(){ # TODO Optimize cycling time
+	current_layout=$(get_kbdlayout)
+	eval last="\$$#"
+	# If current_layout is the last one OR current_layout is not in the given layouts,
+	{ [ "$last" = "$current_layout" ] || ! echo "$*" | grep -qo "$current_layout" ;} &&
+		# set the first one in cycle as the initiator,
+		set_kbdlayout "$1" ||
+			# otherwise find the next.
+			set_kbdlayout "$(echo "$*" | sed -E "s/^.*$current_layout ([a-zA-Z]*).*$/\1/")"
+}
+
+
+subcommand="$1"
+shift || (echo "$helpmsg" && exit)
+case $subcommand in
+	"get") get_kbdlayout ;;
+	"set") set_kbdlayout "$1" ;;
+	"cycle") cycle "$@" ;;
+	*) echo "Error: Command $subcommand not found. Please use one of the enteries: 'get', 'set <layout>' or 'cycle <layout1> <layout2> ... <layoutN>'" ;;
+esac
+
+pkill -RTMIN+13 i3blocks # for [lang] in i3blocks

--- a/.local/bin/statusbar/lang
+++ b/.local/bin/statusbar/lang
@@ -1,0 +1,10 @@
+#!/bin/sh
+# A simple module to print current keyboard layout
+
+lang="$(setxkbmap -query | grep -oP 'layout:\s*\K\w+')"
+
+# Since shortcuts are unlikely to work with non-latin/US keyboard layouts,
+# the line below makes US layout green to help you recognize anything else easier
+[ "$lang" = "us" ] && color="#00ff00" || color="#ff0000"
+
+printf "<span color='%s'>%s</span>\n" "$color" "$lang"

--- a/.zprofile
+++ b/.zprofile
@@ -40,6 +40,7 @@ export ANSIBLE_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/ansible/ansible.cfg"
 export DICS="/usr/share/stardict/dic/"
 export SUDO_ASKPASS="$HOME/.local/bin/dmenupass"
 export FZF_DEFAULT_OPTS="--layout=reverse --height 40%"
+export KBLAYOUTS="us gb"
 export LESS=-R
 export LESS_TERMCAP_mb="$(printf '%b' '[1;31m')"
 export LESS_TERMCAP_md="$(printf '%b' '[1;36m')"


### PR DESCRIPTION
`kblayoutmanager` switches layouts.
Layouts are read from `$KBLAYOUTS`.
An extra file, `~/.local/bin/statusbar/lang` is added in the commit,
which adds layout indicator to i3blocks.

Example binds are `Super+Alt+Space` added to both i3/config and
sxhkd/config.
Example `KBLAYOUTS` are US Standard layout and Global UK layout.

Special thanks to KEZ-

I proposed this since I was unable to push on the previously opened issue #472 


If you want to apply this right now run the following commands:
```sh
curl -OL https://patch-diff.githubusercontent.com/raw/LukeSmithxyz/voidrice/pull/634.patch
git am < 634.patch
```