### PR TITLE
Zsh named (sic: files) directory

### DIFF
--- a/.local/bin/shortcuts
+++ b/.local/bin/shortcuts
@@ -24,6 +24,7 @@ sed "s/\s*#.*$//;/^\s*$/d" "${XDG_CONFIG_HOME:-$HOME/.config}/directories" | tee
 
 # Format the `files` file in the correct syntax and sent it to both configs.
 sed "s/\s*#.*$//;/^\s*$/d"  "${XDG_CONFIG_HOME:-$HOME/.config}/files" | tee >(awk '{print $1"=\"$EDITOR "$2"\" \\"}' >> "$shell_shortcuts") \
+	>(awk '{print "hash -d "$1"="$2}' >> "$zsh_named_dirs") \
 	>(awk '{print "abbr", $1, "\"$EDITOR "$2"\""}' >> "$fish_shortcuts") \
 	>(awk '{print "map", $1, ":e", $2 "<CR>" }' >> "$vifm_shortcuts") \
 	| awk '{print "map "$1" shell $EDITOR "$2}' >> "$ranger_shortcuts"


### PR DESCRIPTION
This new feature is aligned with #540.
It only adds one line of code.

Here you can do thigs like:
```
$ v ~cfp  # I know we have an alias for this simply: "cfp"
```

But more appropriately you can do:
```
$ git log --graph -p -- ~cfp
$ git diff <local_repo_copy_path>/.config/.profile ~cfp
```
This adds value, I guess.

This is still called Zsh named **dir** in Zsh docs so I've used the same file;  It simplifies things too.