### PR TITLE
Add case-insensitive autocompletion to zsh

### DIFF
--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -19,6 +19,7 @@ HISTFILE=~/.cache/zsh/history
 # Basic auto/tab complete:
 autoload -U compinit
 zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
 zmodload zsh/complist
 compinit
 _comp_options+=(globdots)		# Include hidden files.


### PR DESCRIPTION
When using tab completion in zsh, it can get annoying to type capital letters for directories.

This fix allows for case-insensitive completion, e.g. `/etc/x => tab` will also include `X11` in the options menu.