### PR TITLE
stderr suppression & empty string flag

### DIFF
--- a/.local/bin/ext
+++ b/.local/bin/ext
@@ -7,38 +7,38 @@
 # Behavior with `-c` option: Extract contents into current directory
 
 while getopts "hc" o; do case "${o}" in
-	c) extracthere="True" ;;
-	*) printf "Options:\\n   -c: Extract archive into current directory rather than a new one.\\n" && exit ;;
-esac done
+    c) extracthere="True" ;;
+    *) printf "Options:\\n   -c: Extract archive into current directory rather than a new one.\\n" && exit ;;
+    esac; done
 
 if [ -z "$extracthere" ]; then
-	archive="$(readlink -f "$*")" &&
-	directory="$(echo "$archive" | sed 's/\.[^\/.]*$//')" &&
-	mkdir -p "$directory" &&
-	cd "$directory" || exit
+    archive="$(readlink -f "$*")" &&
+        directory="$(echo "$archive" | sed 's/\.[^\/.]*$//')" &&
+        mkdir -p "$directory" &&
+        cd "$directory" || exit
 else
-	archive="$(readlink -f "$(echo "$*" | cut -d' ' -f2)")"
+    archive="$(readlink -f "$(echo "$*" | cut -d' ' -f2)" 2>/dev/null)"
 fi
 
-[ "$archive" = "" ] && printf "Give archive to extract as argument.\\n" && exit
+[ -z "$archive" ] && printf "Give archive to extract as argument.\\n" && exit
 
-if [ -f "$archive" ] ; then
-	case "$archive" in
-		*.tar.bz2|*.tbz2) tar xvjf "$archive" ;;
-		*.tar.xz) tar -xf "$archive" ;;
-		*.tar.gz|*.tgz) tar xvzf "$archive" ;;
-		*.lzma) unlzma "$archive" ;;
-		*.bz2) bunzip2 "$archive" ;;
-		*.rar) unrar x -ad "$archive" ;;
-		*.gz) gunzip "$archive" ;;
-		*.tar) tar xvf "$archive" ;;
-		*.zip) unzip "$archive" ;;
-		*.Z) uncompress "$archive" ;;
-		*.7z) 7z x "$archive" ;;
-		*.xz) unxz "$archive" ;;
-		*.exe) cabextract "$archive" ;;
-		*) printf "extract: '%s' - unknown archive method\\n" "$archive" ;;
-	esac
+if [ -f "$archive" ]; then
+    case "$archive" in
+    *.tar.bz2 | *.tbz2) tar xvjf "$archive" ;;
+    *.tar.xz) tar -xf "$archive" ;;
+    *.tar.gz | *.tgz) tar xvzf "$archive" ;;
+    *.lzma) unlzma "$archive" ;;
+    *.bz2) bunzip2 "$archive" ;;
+    *.rar) unrar x -ad "$archive" ;;
+    *.gz) gunzip "$archive" ;;
+    *.tar) tar xvf "$archive" ;;
+    *.zip) unzip "$archive" ;;
+    *.Z) uncompress "$archive" ;;
+    *.7z) 7z x "$archive" ;;
+    *.xz) unxz "$archive" ;;
+    *.exe) cabextract "$archive" ;;
+    *) printf "extract: '%s' - unknown archive method\\n" "$archive" ;;
+    esac
 else
-	printf "File \"%s\" not found.\\n" "$archive"
+    printf "File \"%s\" not found.\\n" "$archive"
 fi


### PR DESCRIPTION
- `[ "$archive" = "" ] ` ==` [ -z "$archive" ]`
- upon entering `ext -c` with no arguments you will also generate an error from `readlink`, should be suppressed

also sorry for the formatting, `shfmt` got in the way