### PR TITLE
distro-specific aliases

### DIFF
--- a/.config/aliasrc
+++ b/.config/aliasrc
@@ -30,11 +30,20 @@ alias \
 	f="$FILE" \
 	e="$EDITOR" \
 	v="$EDITOR" \
-	p="sudo pacman" \
-	xi="sudo xbps-install" \
-	xr="sudo xbps-remove -R" \
-	xq="xbps-query" \
 	z="zathura"
+
+# distro-specific aliases
+# arch
+[ -x "$(command -v pacman)" ] &&
+    alias \
+        p="sudo pacman"
+
+# void
+[ -x "$(command -v xbps)" ] &&
+    alias \
+        xi="sudo xbps-install" \
+        xr="sudo xbps-remove -R" \
+        xq="xbps-query"
 
 alias \
 	magit="nvim -c MagitOnly" \


### PR DESCRIPTION
haven't really tested how efficient/inefficient it is to check commands every time you launch for shell, but i found this useful; you may even make general aliases with the same name across all distributions. this means you don't even have have to remember every single alias separately.

this is what i'm currently using:
```sh
## distro-specific aliases
# arch
[ -x "$(command -v pacman)" ] &&
    alias \
        pkgf="pacman -Ss" \
        pkgi="sudo pacman -S" \
        pkgr="sudo pacman -R" \
        pkgu="sudo pacman -Suyy"

# void
[ -x "$(command -v xbps)" ] &&
    alias \
        pkgf="xbps-query -s" \
        pkgi="sudo xbps-install -S" \
        pkgr="sudo xbps-remove" \
        pkgu="sudo xbps-install -Su"
```