### PR TITLE
Fix sxiv .desktop file

### DIFF
--- a/.local/share/applications/img.desktop
+++ b/.local/share/applications/img.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Type=Application
 Name=Image viewer
-Exec=/usr/bin/sxiv -a %u
+Exec=/usr/bin/sxiv -a %f


### PR DESCRIPTION
Would previously error out as such:

```
Opening "<file>" with Image viewer  (image/jpeg)
sxiv: file://<filepath>
sxiv: No valid image file given, aborting
```