### PR TITLE
adds 2 digits for last track for cases when less than 10 tracks

### DIFF
--- a/.local/bin/booksplit
+++ b/.local/bin/booksplit
@@ -39,6 +39,6 @@ do
 done < "$2"
 # The last track must be done outside the loop.
 echo "From $start to the end: $title"
-file="$escbook/$track-$esctitle.$ext"
+file="$escbook/$(printf "%.2d" "$track")-$esctitle.$ext"
 echo "Splitting \"$title\"..." && ffmpeg -nostdin -y -loglevel -8 -i "$inputaudio" -ss "$start" -vn "$file" &&
 		echo "Tagging \"$title\"..." && tag -a "$author" -A "$booktitle" -t "$title" -n "$track" -N "$total" -d "$year" "$file"


### PR DESCRIPTION
I used your script but on an album with 8 tracks, and the last one ended up not having a leading zero like the rest. This should fix it.