### PR TITLE
Use read instead of parameter expansions

### DIFF
--- a/.local/bin/statusbar/nettraf
+++ b/.local/bin/statusbar/nettraf
@@ -11,13 +11,14 @@ case "$BLOCK_BUTTON" in
 esac
 
 logfile="${XDG_CACHE_HOME:-$HOME/.cache}/netlog"
-prevdata="$(cat "$logfile")" || echo "0 0" > "$logfile"
+
+[ -f "$logfile" ] && read rxprev txprev < "$logfile"
 
 rxcurrent="$(($(paste -d '+' /sys/class/net/[ew]*/statistics/rx_bytes)))"
 txcurrent="$(($(paste -d '+' /sys/class/net/[ew]*/statistics/tx_bytes)))"
 
 printf "🔻%sKiB 🔺%sKiB\\n" \
-	"$(((rxcurrent-${prevdata%% *})/1024))" \
-	"$(((txcurrent-${prevdata##* })/1024))"
+	"$(((rxcurrent-rxprev)/1024))" \
+	"$(((txcurrent-txprev)/1024))"
 
 echo "$rxcurrent $txcurrent" > "$logfile"


### PR DESCRIPTION
A suggestion to get rid of the parameter expansions (I always found them weird). 

`read` could also be easily changed to handle more than two values (if someone would like to keep track of more statistics). 