### PR TITLE
Replace case with a function call

### DIFF
--- a/.local/bin/lmc
+++ b/.local/bin/lmc
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+COMMAND="${1:-help}"
 NUM="${2:-5}"
 
 # Uncomment the following line to use Pulseaudio.
@@ -19,10 +20,12 @@ else
 	control() { alsamixer ;}
 fi
 
-case "$1" in
-	toggle) toggle ;;
-	mute) mute ;;
-	up) up ;;
-	down) down ;;
-	control) control ;;
-esac
+help() {
+	echo "usage: lmc <command> [<num>]"
+	echo "commands:"
+	sed -n 's/^\s*\(\S*\)().*/- \1/p' "$0" | sort -u
+}
+
+type "$COMMAND" | grep function >/dev/null && "$COMMAND" \
+	|| echo "lmc: command not defined: $COMMAND" >&2
+


### PR DESCRIPTION
The idea: Replace
```bash
case "$1" in
	toggle) toggle ;;
	mute) mute ;;
	up) up ;;
	down) down ;;
	control) control ;;
esac
```
with
```bash
"$1"
```

But then you can also do `lmc ls` and the ls will run, so the `type "$COMMAND" | grep function` ensures that the passed command is one of the commands.

The `help()` is just bloat.
