### PR TITLE
Changed mpv newsboat command to run outside newsboat with nohup 8.31

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -33,7 +33,7 @@ browser linkhandler
 macro , open-in-browser
 macro t set browser "qndl"; open-in-browser ; set browser linkhandler
 macro a set browser "tsp youtube-dl --add-metadata -xic -f bestaudio/best"; open-in-browser ; set browser linkhandler
-macro v set browser "setsid nohup mpv"; open-in-browser ; set browser linkhandler
+macro v set browser "setsid nohup mpv %u &>/dev/null &"; open-in-browser ; set browser linkhandler
 macro w set browser "lynx"; open-in-browser ; set browser linkhandler
 macro p set browser "dmenuhandler"; open-in-browser ; set browser linkhandler
 macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkhandler


### PR DESCRIPTION
Using this macro with nohup and setsid of versions below creates a nohup.out in the current directory and replaces newsboat window with mpv control:

![image](https://user-images.githubusercontent.com/9886026/83347098-f21d4f00-a311-11ea-8fbe-d232cc520f9f.png)

If the command from proposed newsboat config is used, newsboat window remains operable.

```
nohup (GNU coreutils) 8.31
Packaged by Gentoo (8.31-r1 (p0))
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jim Meyering.
```
```
setsid from util-linux 2.35.1
```
