### PR TITLE
Cleaner & bug free startx

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -120,7 +120,7 @@ ex=🎯:\
 
 if pacman -Qs libxft-bgra >/dev/null 2>&1; then
 	# Start graphical server on tty1 if not already running.
-	[ "$(tty)" = "/dev/tty1" ] && ! pidof Xorg >/dev/null 2>&1  && exec startx
+   [ "$(fgconsole 2> /dev/null)" = 1 ] && exec startx
 else
 	echo "\033[31mIMPORTANT\033[0m: Note that \033[32m\`libxft-bgra\`\033[0m must be installed for this build of dwm.
 Please run:


### PR DESCRIPTION
My goal here was to clean up a bit and use one less program (pidof) to start the x server.
But after further testing, I have noticed this fixes a major issue.
For some weird reason, your version auto started the X on  all of my VTs instead of the first one.
It might just be the fact that I am auto logging on my VT, I'm not sure though.
Either way, my version seems to be working fine without any issue.
