### PR TITLE
newsbloat 2.20 compliant

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -31,11 +31,11 @@ color article white default bold
 
 browser linkhandler
 macro , open-in-browser
-macro t set browser "qndl"; open-in-browser ; set browser linkhandler
-macro a set browser "tsp youtube-dl --add-metadata -xic -f bestaudio/best"; open-in-browser ; set browser linkhandler
-macro v set browser "setsid -f mpv"; open-in-browser ; set browser linkhandler
-macro w set browser "lynx"; open-in-browser ; set browser linkhandler
-macro p set browser "dmenuhandler"; open-in-browser ; set browser linkhandler
+macro t set browser "qndl" ; open-in-browser ; set browser linkhandler
+macro a set browser "tsp youtube-dl --add-metadata -xic -f bestaudio/best" ; open-in-browser ; set browser linkhandler
+macro v set browser "setsid -f mpv" ; open-in-browser ; set browser linkhandler
+macro w set browser "lynx" ; open-in-browser ; set browser linkhandler
+macro p set browser "dmenuhandler" ; open-in-browser ; set browser linkhandler
 macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkhandler
 
 highlight all "---.*---" yellow


### PR DESCRIPTION
the `;` must be surrounded with space, or you wont be able to open stuff