### PR TITLE
keyboard layout switch

### DIFF
--- a/.local/bin/statusbar/kbselect
+++ b/.local/bin/statusbar/kbselect
@@ -1,0 +1,15 @@
+#!/bin/bash
+# works on any init system
+# requirements: dmenu, xorg-setxkbmap, xkblayout-state (https://github.com/nonpop/xkblayout-state)
+kb="$(xkblayout-state print "%s")"
+
+case $BLOCK_BUTTON in
+	1) kb_choice="$(awk '/! layout/{flag=1; next} /! variant/{flag=0} flag {print $2, "- " $1}' /usr/share/X11/xkb/rules/base.lst | dmenu -l 15)"
+	kb="$(echo "$kb_choice" | awk '{print $3}')"
+	setxkbmap "$kb"
+	pkill -RTMIN+30 "${STATUSBAR:-dwmblocks}";;
+	3) notify-send "$(xkblayout-state print "Current layout: %s(%n)")";;
+	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+esac
+
+echo "$kb"


### PR DESCRIPTION
Works on any init system.
Requirements: dmenu, xorg-setxkbmap, xkblayout-state (https://github.com/nonpop/xkblayout-state)

Add this line to Luke's dwmblocks
{"",	"kbselect",	0,	30},

