### PR TITLE
Prevent error when having no battery

### DIFF
--- a/.local/bin/statusbar/battery
+++ b/.local/bin/statusbar/battery
@@ -20,7 +20,8 @@ esac
 for battery in /sys/class/power_supply/BAT?
 do
 	# Get its remaining capacity and charge status.
-	capacity=$(cat "$battery"/capacity) || break
+	[ -f "$battery"/capacity ] || break
+	capacity=$(cat "$battery"/capacity)
 	status=$(sed "s/[Dd]ischarging/🔋/;s/[Nn]ot charging/🛑/;s/[Cc]harging/🔌/;s/[Uu]nknown/♻️/;s/[Ff]ull/⚡/" "$battery"/status)
 
 	# If it is discharging and 25% or less, we will add a ❗ as a warning.

--- a/.local/bin/statusbar/battery
+++ b/.local/bin/statusbar/battery
@@ -20,8 +20,7 @@ esac
 for battery in /sys/class/power_supply/BAT?
 do
 	# Get its remaining capacity and charge status.
-	[ -f "$battery"/capacity ] || break
-	capacity=$(cat "$battery"/capacity)
+	capacity=$(cat "$battery"/capacity 2>/dev/null) || break
 	status=$(sed "s/[Dd]ischarging/🔋/;s/[Nn]ot charging/🛑/;s/[Cc]harging/🔌/;s/[Uu]nknown/♻️/;s/[Ff]ull/⚡/" "$battery"/status)
 
 	# If it is discharging and 25% or less, we will add a ❗ as a warning.


### PR DESCRIPTION
The current battery script works well on my laptop (that has a battery) but on my desktop (that lacks a battery), it floods my logs with the following because `cat` keeps throwing an error each time the script is run.
```cat: '/sys/class/power_supply/BAT?/capacity': No such file or directory```

This fix breaks the loop if the file doesn't exist before it's being read with `cat`, thus preventing any errors from reading a file not existing.