### PR TITLE
improve speed format

### DIFF
--- a/.local/bin/statusbar/nettraf
+++ b/.local/bin/statusbar/nettraf
@@ -19,10 +19,10 @@ update() {
     cache=${XDG_CACHE_HOME:-$HOME/.cache}/${1##*/}
     [ -f "$cache" ] && read -r old < "$cache" || old=0
     printf %d\\n "$sum" > "$cache"
-    printf %d\\n $(( (sum - old) / 1024 ))
+    printf %d\\n $(( sum - old ))
 }
 
 rx=$(update /sys/class/net/[ew]*/statistics/rx_bytes)
 tx=$(update /sys/class/net/[ew]*/statistics/tx_bytes)
 
-printf "🔻%dKiB 🔺%dKiB\\n" "$rx" "$tx"
+printf "🔻%sB 🔺%sB\\n" $(numfmt --to=iec $rx) $(numfmt --to=iec-i $tx)

--- a/.local/bin/statusbar/nettraf
+++ b/.local/bin/statusbar/nettraf
@@ -25,4 +25,4 @@ update() {
 rx=$(update /sys/class/net/[ew]*/statistics/rx_bytes)
 tx=$(update /sys/class/net/[ew]*/statistics/tx_bytes)
 
-printf "🔻%sB 🔺%sB\\n" $(numfmt --to=iec $rx) $(numfmt --to=iec-i $tx)
+printf "🔻%4sB 🔺%4sB\\n" $(numfmt --to=iec $rx) $(numfmt --to=iec-i $tx)


### PR DESCRIPTION
Convert network speed into human-readable format using numfmt, this will handle low and high values properly.