### PR TITLE
linkhandler: Fix file opening in $EDITOR for Alacritty terminal

### DIFF
--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -17,6 +17,6 @@ case "$1" in
 	*mp3|*flac|*opus|*mp3?source*)
 		setsid -f tsp curl -LO "$1" >/dev/null 2>&1 ;;
 	*)
-		if [ -f "$1" ]; then "$TERMINAL" -e "$EDITOR $1"
+		if [ -f "$1" ]; then "$TERMINAL" -e "$EDITOR" "$1"
 	else setsid -f "$BROWSER" "$1" >/dev/null 2>&1; fi ;;
 esac


### PR DESCRIPTION
"$EDITOR $1" caused a 'file does not exist' error in Alacritty terminal, despite passing the conditional if statement preceding it. Splitting the quotes into "$EDITOR" "$1" fixed the issue. Not sure why.