### PR TITLE
Prevent user-defined aliases/commands checking

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -32,9 +32,9 @@ case "$ext" in
 	go) go run "$file" ;;
 	h) sudo make install ;;
 	m) octave "$file" ;;
-	md)	if  command -v lowdown >/dev/null; then
+	md)	if  [ -x "$(command -v lowdown)" ] >/dev/null; then
 			lowdown -d nointem -e super "$file" -Tms | groff -mpdfmark -ms -kept > "$base".pdf
-		elif command -v groffdown >/dev/null; then
+		elif [ -x "$(command -v groffdown)" ] >/dev/null; then
 			groffdown -i "$file" | groff > "$base.pdf"
 		else
 			pandoc "$file" --pdf-engine=xelatex -o "$base".pdf


### PR DESCRIPTION
Adding `[ -x ]` also checks if the command is an executable; if this
check is skipped, then user-defined aliases will interfere and validate
the condition (unintended).