### PR TITLE
Add macro to view youtube comments

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -37,6 +37,7 @@ macro v set browser "setsid -f mpv" ; open-in-browser ; set browser linkhandler
 macro w set browser "lynx" ; open-in-browser ; set browser linkhandler
 macro p set browser "dmenuhandler" ; open-in-browser ; set browser linkhandler
 macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkhandler
+macro C set browser "youtube-viewer --comments=%u" ; open-in-browser ; set browser linkhandler
 
 highlight all "---.*---" yellow
 highlight feedlist ".*(0/0))" black


### PR DESCRIPTION
Adds macro to newsboat to view youtube comments from command line. Requires youtube-viewer.