### PR TITLE
Let zathura use the normal clipboard

### DIFF
--- a/.config/zathura/zathurarc
+++ b/.config/zathura/zathurarc
@@ -1,6 +1,7 @@
 set statusbar-h-padding 0
 set statusbar-v-padding 0
 set page-padding 1
+set selection-clipboard clipboard
 map u scroll half-up
 map d scroll half-down
 map D toggle_page_mode


### PR DESCRIPTION
Letting zathura use the standard clipboard by default makes using it more intuitive.
We just have to select the zone to copy with our cursor and then it is directly usable with a CTRL-V in any windows.