### PR TITLE
Update .zprofile

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -6,7 +6,7 @@
 # to clean up.
 
 # Adds `~/.local/bin` to $PATH
-export PATH="$PATH:$(du "$HOME/.local/bin/" | cut -f2 | paste -sd ':')"
+export PATH="$PATH:$(du "$HOME/.local/bin" | cut -f2 | paste -sd ':')"
 
 # Default programs:
 export EDITOR="nvim"


### PR DESCRIPTION
Remove trailing slash from local bin directories in PATH

This is not important, but with the trailing slash you get it doubled in some commands like:
```
type weather
weather is /home/jamazi/.local/bin//statusbar/weather
```