### PR TITLE
Use `pkill` instead of `killall`

### DIFF
--- a/.config/aliasrc
+++ b/.config/aliasrc
@@ -22,7 +22,7 @@ alias \
 
 # These common commands are just too long! Abbreviate them.
 alias \
-	ka="pkill -9" \
+	ka="pkill -15" \
 	g="git" \
 	trem="transmission-remote" \
 	YT="youtube-viewer" \

--- a/.config/aliasrc
+++ b/.config/aliasrc
@@ -22,7 +22,7 @@ alias \
 
 # These common commands are just too long! Abbreviate them.
 alias \
-	ka="killall" \
+	ka="pkill -9" \
 	g="git" \
 	trem="transmission-remote" \
 	YT="youtube-viewer" \

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -271,7 +271,7 @@ bindsym $mod+Shift+bracketright exec --no-startup-id mpc seek +120
 bindsym Print 			exec --no-startup-id maim pic-full-"$(date '+%y%m%d-%H%M-%S').png"
 bindsym Shift+Print 		exec --no-startup-id maimpick
 bindsym $mod+Print		exec --no-startup-id dmenurecord
-bindsym $mod+Scroll_Lock	exec --no-startup-id "killall screenkey || screenkey"
+bindsym $mod+Scroll_Lock	exec --no-startup-id "pkill -9 screenkey || screenkey"
 bindsym $mod+Delete		exec $stoprec
 bindsym XF86Launch1		exec --no-startup-id xset dpms force off
 

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -271,7 +271,7 @@ bindsym $mod+Shift+bracketright exec --no-startup-id mpc seek +120
 bindsym Print 			exec --no-startup-id maim pic-full-"$(date '+%y%m%d-%H%M-%S').png"
 bindsym Shift+Print 		exec --no-startup-id maimpick
 bindsym $mod+Print		exec --no-startup-id dmenurecord
-bindsym $mod+Scroll_Lock	exec --no-startup-id "pkill -9 screenkey || screenkey"
+bindsym $mod+Scroll_Lock	exec --no-startup-id "pkill -15 screenkey || screenkey"
 bindsym $mod+Delete		exec $stoprec
 bindsym XF86Launch1		exec --no-startup-id xset dpms force off
 

--- a/.config/ranger/rc.conf
+++ b/.config/ranger/rc.conf
@@ -114,7 +114,7 @@ map cd console cd%space
 #map Mb shell mocp -r
 #map MN shell mocp -s && mocp -c && mocp -a %s && mocp -p
 #map Mo shell mocp -j 0%%
-#map MK shell killall mocp
+#map MK shell pkill -9 mocp
 
 # Tagging / Marking
 map at      tag_toggle
@@ -475,14 +475,14 @@ map Txh console shell cp ~/Documents/LaTeX/handout.tex%space
 #Image commands
 map bg shell setbg %f
 map bw shell wal -i %f && setbg %f
-map C shell killall w3mimgdisplay && convert -rotate 90 %s %s
-map F shell killall w3mimgdisplay && convert -flop %s %s
-map bl shell killall w3mimgdisplay && convert %s -resize 1440x1080\> bl_%s
+map C shell pkill -9 w3mimgdisplay && convert -rotate 90 %s %s
+map F shell pkill -9 w3mimgdisplay && convert -flop %s %s
+map bl shell pkill -9 w3mimgdisplay && convert %s -resize 1440x1080\> bl_%s
 map TR shell convert %s -transparent white %s
 
 #Music (mpd) shortcuts
 map MS shell mpd
-map MK shell killall mpd
+map MK shell pkill -9 mpd
 map Ma shell mpc add "%s"
 map Ms shell mpc play
 map Mp shell mpc toggle

--- a/.config/ranger/rc.conf
+++ b/.config/ranger/rc.conf
@@ -114,7 +114,7 @@ map cd console cd%space
 #map Mb shell mocp -r
 #map MN shell mocp -s && mocp -c && mocp -a %s && mocp -p
 #map Mo shell mocp -j 0%%
-#map MK shell pkill -9 mocp
+#map MK shell pkill -15 mocp
 
 # Tagging / Marking
 map at      tag_toggle
@@ -475,14 +475,14 @@ map Txh console shell cp ~/Documents/LaTeX/handout.tex%space
 #Image commands
 map bg shell setbg %f
 map bw shell wal -i %f && setbg %f
-map C shell pkill -9 w3mimgdisplay && convert -rotate 90 %s %s
-map F shell pkill -9 w3mimgdisplay && convert -flop %s %s
-map bl shell pkill -9 w3mimgdisplay && convert %s -resize 1440x1080\> bl_%s
+map C shell pkill -15 w3mimgdisplay && convert -rotate 90 %s %s
+map F shell pkill -15 w3mimgdisplay && convert -flop %s %s
+map bl shell pkill -15 w3mimgdisplay && convert %s -resize 1440x1080\> bl_%s
 map TR shell convert %s -transparent white %s
 
 #Music (mpd) shortcuts
 map MS shell mpd
-map MK shell pkill -9 mpd
+map MK shell pkill -15 mpd
 map Ma shell mpc add "%s"
 map Ms shell mpc play
 map Mp shell mpc toggle

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -39,7 +39,7 @@ super + shift + w
 super + grave
 	dmenuunicode
 super + Scroll_Lock
-	pkill -9 screenkey || screenkey
+	pkill -15 screenkey || screenkey
 super + Insert
 	showclip
 super + shift + x
@@ -47,7 +47,7 @@ super + shift + x
 super + shift + BackSpace
 	prompt "Reboot computer?" "sudo -A reboot"
 super + shift + Escape
-	prompt 'Leave Xorg?' 'pkill -x Xorg'
+	prompt 'Leave Xorg?' 'pkill -15 Xorg'
 super + x
 	ifinstalled slock && ( slock & xset dpms force off ; mpc pause ; pauseallmpv )
 XF86Launch1
@@ -260,7 +260,7 @@ super + o
 
 # remove and restore polybar
 #super + b
-#\{ pgrep polybar && \{ pkill -9 polybar ; bspc config top_padding 0 \} \} || \{ launch_polybar ; bspc config top_padding 24 \}
+#\{ pgrep polybar && \{ pkill -15 polybar ; bspc config top_padding 0 \} \} || \{ launch_polybar ; bspc config top_padding 24 \}
 
 super + {i,o}
 	bspc node -f {prev,next}.local

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -39,7 +39,7 @@ super + shift + w
 super + grave
 	dmenuunicode
 super + Scroll_Lock
-	killall screenkey || screenkey
+	pkill -9 screenkey || screenkey
 super + Insert
 	showclip
 super + shift + x
@@ -47,7 +47,7 @@ super + shift + x
 super + shift + BackSpace
 	prompt "Reboot computer?" "sudo -A reboot"
 super + shift + Escape
-	prompt 'Leave Xorg?' 'killall Xorg'
+	prompt 'Leave Xorg?' 'pkill -x Xorg'
 super + x
 	ifinstalled slock && ( slock & xset dpms force off ; mpc pause ; pauseallmpv )
 XF86Launch1
@@ -260,7 +260,7 @@ super + o
 
 # remove and restore polybar
 #super + b
-#\{ pgrep polybar && \{ killall polybar ; bspc config top_padding 0 \} \} || \{ launch_polybar ; bspc config top_padding 24 \}
+#\{ pgrep polybar && \{ pkill -9 polybar ; bspc config top_padding 0 \} \} || \{ launch_polybar ; bspc config top_padding 24 \}
 
 super + {i,o}
 	bspc node -f {prev,next}.local

--- a/.local/bin/displayselect
+++ b/.local/bin/displayselect
@@ -59,7 +59,7 @@ onescreen() { # If only one output available or chosen.
 postrun() { # Stuff to run to clean up.
 	setbg		# Fix background if screen size/arangement has changed.
 	remaps		# Re-remap keys if keyboard added (for laptop bases)
-	{ killall dunst ; setsid -f dunst ;} >/dev/null 2>&1 # Restart dunst to ensure proper location on screen
+	{ pkill -9 dunst ; setsid -f dunst ;} >/dev/null 2>&1 # Restart dunst to ensure proper location on screen
 	}
 
 # Get all possible displays

--- a/.local/bin/displayselect
+++ b/.local/bin/displayselect
@@ -59,7 +59,7 @@ onescreen() { # If only one output available or chosen.
 postrun() { # Stuff to run to clean up.
 	setbg		# Fix background if screen size/arangement has changed.
 	remaps		# Re-remap keys if keyboard added (for laptop bases)
-	{ pkill -9 dunst ; setsid -f dunst ;} >/dev/null 2>&1 # Restart dunst to ensure proper location on screen
+	{ pkill -15 dunst ; setsid -f dunst ;} >/dev/null 2>&1 # Restart dunst to ensure proper location on screen
 	}
 
 # Get all possible displays

--- a/.local/bin/launch_polybar
+++ b/.local/bin/launch_polybar
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Terminate already running bar instances
-pkill -9 -q polybar
+pkill -15 -q polybar
 
 # Wait until the processes have been shut down
 while pidof polybar >/dev/null; do sleep 1; done

--- a/.local/bin/launch_polybar
+++ b/.local/bin/launch_polybar
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Terminate already running bar instances
-killall -q polybar
+pkill -9 -q polybar
 
 # Wait until the processes have been shut down
 while pidof polybar >/dev/null; do sleep 1; done

--- a/.local/bin/remaps
+++ b/.local/bin/remaps
@@ -6,6 +6,6 @@ xset r rate 300 50
 # Map the caps lock key to super...
 setxkbmap -option caps:super
 # But when it is pressed only once, treat it as escape.
-killall xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
+pkill -9 xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
 # Map the menu button to right super as well.
 xmodmap -e 'keycode 135 = Super_R'

--- a/.local/bin/remaps
+++ b/.local/bin/remaps
@@ -6,6 +6,6 @@ xset r rate 300 50
 # Map the caps lock key to super...
 setxkbmap -option caps:super
 # But when it is pressed only once, treat it as escape.
-pkill -9 xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
+pkill -15 xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
 # Map the menu button to right super as well.
 xmodmap -e 'keycode 135 = Super_R'

--- a/.local/bin/td-toggle
+++ b/.local/bin/td-toggle
@@ -4,7 +4,7 @@
 
 if pidof transmission-daemon >/dev/null ;
 then
-	[ "$(printf "No\\nYes" | dmenu -i -p "Turn off transmission-daemon?")" = "Yes" ] && pkill -9 transmission-da && notify-send "transmission-daemon disabled."
+	[ "$(printf "No\\nYes" | dmenu -i -p "Turn off transmission-daemon?")" = "Yes" ] && pkill -15 transmission-da && notify-send "transmission-daemon disabled."
 else
 	ifinstalled transmission-cli || exit
 	[ "$(printf "No\\nYes" | dmenu -i -p "Turn on transmission daemon?")" = "Yes" ] && transmission-daemon && notify-send "tranmission-daemon enabled."

--- a/.local/bin/td-toggle
+++ b/.local/bin/td-toggle
@@ -4,7 +4,7 @@
 
 if pidof transmission-daemon >/dev/null ;
 then
-	[ "$(printf "No\\nYes" | dmenu -i -p "Turn off transmission-daemon?")" = "Yes" ] && killall transmission-da && notify-send "transmission-daemon disabled."
+	[ "$(printf "No\\nYes" | dmenu -i -p "Turn off transmission-daemon?")" = "Yes" ] && pkill -9 transmission-da && notify-send "transmission-daemon disabled."
 else
 	ifinstalled transmission-cli || exit
 	[ "$(printf "No\\nYes" | dmenu -i -p "Turn on transmission daemon?")" = "Yes" ] && transmission-daemon && notify-send "tranmission-daemon enabled."


### PR DESCRIPTION
The `killall` command doesn't come shipped in all distributions (Void
Linux as an example), on the other hand `pkill` does.

Unsure what the exact intention on each call is but the `-9` signal can be
replaced with `-x` if the intention is not to end all instances.

Also note that I left `pkill -x Xorg` without the `-9` signal because
for some reason it won't function as expected and end up halting the
system (at least on Void Linux).