### PR TITLE
Add a working toggletouchpad script

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -331,8 +331,8 @@ bindsym XF86Reload		restart
 ##bindsym XF86Launch9		exec
 #bindsym XF86AudioMicMute	exec $micmute
 bindsym XF86TouchpadToggle	exec --no-startup-id toggletouchpad
-bindsym XF86TouchpadOn		exec --no-startup-id synclient TouchpadOff=0
-bindsym XF86TouchpadOff		exec --no-startup-id synclient TouchpadOff=1
+bindsym XF86TouchpadOn		exec --no-startup-id toggletouchpad 1
+bindsym XF86TouchpadOff		exec --no-startup-id toggletouchpad 0
 bindsym XF86Suspend		exec --no-startup-id lockscreen
 bindsym XF86Close		kill
 bindsym XF86WebCam		exec --no-startup-id camtoggle

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -53,9 +53,9 @@ super + x
 XF86Launch1
 	xset dpms force off
 XF86TouchpadToggle
-	(synclient | grep "TouchpadOff.*1" && synclient TouchpadOff=0) || synclient TouchpadOff=1
+	toggletouchpad
 XF86Touchpad{Off,On}
-	synclient TouchpadOff={1,0}
+	toggletouchpad {0,1}
 XF86MonBrightnessDown
 	xbacklight -dec 15
 XF86MonBrightnessUp

--- a/.local/bin/toggletouchpad
+++ b/.local/bin/toggletouchpad
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Toggles touchpad status
+# 0 as input disables the touchpad and anything else enables it. In case no input is provided, simply toggles it.
+# requirements: libinput, xinput
+
+toggleto(){ [ "$1" = "0" ] && xinput disable "$device" || xinput enable "$device" ;}
+
+device="$(xinput list | grep -P '(?<= )[\w\s:]*(?i)(touchpad|synaptics)(?-i).*?(?=\s*id)' -o | head -n1)"
+# If there is an input switch to that, otherwise just toggle
+toggleto "${1:-$([ "$(xinput list-props "$device" | grep -P ".*Device Enabled.*\K.(?=$)" -o)" = "1" ] && echo 0)}"


### PR DESCRIPTION
The old method doesn't work without `synclient` which is no longer maintained nor suggested. While I suppose that `xinput` and `libinput` are installed on any graphical setups.

Also, there were issues with it. For example, it didn't work on some systems and click keys kept working even if the user set `TouchpadOff=1` (IDK if there is another separate variable for keys or not. Checked, couldn't find any).

Sorry! I know it's a spaghetti...