### PR TITLE
Add termporary wm support to xinitrc

### DIFF
--- a/.config/xinitrc
+++ b/.config/xinitrc
@@ -8,14 +8,32 @@
 # screen) and so they are needed there. To prevent doubling up commands, I
 # source them here with the line below.
 
-# export STATUSBAR="i3blocks" # Uncomment this line when using i3.
-
 . ~/.xprofile
 
 # Your default LARBS WM is determined in your `~/.profile` on login.  Here we
 # run the proper command to run when the graphical environment starts.
+# In order to temporarily overwrite the default WM, you can run something
+# like `xinit ~/.xinitrc bspwm`
 
-# Comment/uncomment these lines depending on what wm you want to use. Also
-# check the i3blocks line above.
-ssh-agent dwm
-# ssh-agent i3
+
+case ${1:-${WM:-dwm}} in
+    a*) exec awesome ;;
+    bs*) exec bspwm ;;
+    bu*) exec budgie-desktop ;;
+    c*) exec cinnamon-session ;;
+    dd*) exec startdde ;;
+    dwm) ssh-agent dwm ;;
+    e*) exec enlightenment_start ;;
+    f*) exec startfluxbox ;;
+    g*) exec gnome-session ;;
+    i3*) export STATUSBAR="i3blocks" && ssh-agent i3 --shmlog-size 0 ;;
+    j*) exec jwm ;;
+    lxd*) exec startlxde ;;
+    lxq*) exec lxqt-session ;;
+    m*) exec mate-session ;;
+    o*) exec openbox-session ;;
+    x*) exec xfce4-session ;;
+    k* | plasma-x*) exec startplasma-x11 ;;
+    plasma-w*) exec startplasma-wayland ;;
+    *) exec ${1:-$WM} ;;
+esac

--- a/.zprofile
+++ b/.zprofile
@@ -130,7 +130,7 @@ ex=🎯:\
 
 [ ! -f ${XDG_CONFIG_HOME:-$HOME/.config}/shortcutrc ] && shortcuts >/dev/null 2>&1 &
 
-if pacman -Qs libxft-bgra >/dev/null 2>&1; then
+if [ "$WM" != "dwm" ] || pacman -Qs libxft-bgra >/dev/null 2>&1 ;then
 	# Start graphical server on tty1 if not already running.
 	[ "$(tty)" = "/dev/tty1" ] && ! pidof Xorg >/dev/null 2>&1  && exec startx
 else


### PR DESCRIPTION
With this patch you can start a desktop without tweaking your dotfiles like this: `xinit ~/.xinitrc wm`, which helps with rapid development across multiple desktops.