### PR TITLE
Update "clock" to show appointments

### DIFF
--- a/.local/bin/statusbar/clock
+++ b/.local/bin/statusbar/clock
@@ -19,7 +19,7 @@ case "$clock" in
 esac
 
 case $BLOCK_BUTTON in
-	1) notify-send "This Month" "$(cal --color=always | sed "s/..7m/<b><span color=\"red\">/;s/..27m/<\/span><\/b>/")" && notify-send "Appointments" "$(calcurse -D ~/.config/calcurse -d3)" ;;
+	1) notify-send "This Month" "$(cal --color=always | sed "s/..7m/<b><span color=\"red\">/;s/..27m/<\/span><\/b>/")" && notify-send "Appointments" "$(calcurse -D ~/.local/share/calcurse -d3)" ;;
 	2) setsid -f "$TERMINAL" -e calcurse ;;
 	3) notify-send "📅 Time/date module" "\- Left click to show upcoming appointments for the next three days via \`calcurse -d3\` and show the month via \`cal\`
 - Middle click opens calcurse if installed" ;;


### PR DESCRIPTION
Update "clock" in "~/.local/bin/statusbar" to show appointments. The updated version points clacurse with "-D" option to the current data directory at "~/.local/share/calcurse".