### PR TITLE
Exit codes, stderr suppression, minor edits

### DIFF
--- a/.local/bin/ext
+++ b/.local/bin/ext
@@ -8,19 +8,19 @@
 
 while getopts "hc" o; do case "${o}" in
 	c) extracthere="True" ;;
-	*) printf "Options:\\n   -c: Extract archive into current directory rather than a new one.\\n" && exit ;;
+	*) printf "Options:\\n   -c: Extract archive into current directory rather than a new one.\\n" && exit 1 ;;
 esac done
 
 if [ -z "$extracthere" ]; then
 	archive="$(readlink -f "$*")" &&
 	directory="$(echo "$archive" | sed 's/\.[^\/.]*$//')" &&
 	mkdir -p "$directory" &&
-	cd "$directory" || exit
+	cd "$directory" || exit 1
 else
-	archive="$(readlink -f "$(echo "$*" | cut -d' ' -f2)")"
+	archive="$(readlink -f "$(echo "$*" | cut -d' ' -f2)" 2>/dev/null)"
 fi
 
-[ "$archive" = "" ] && printf "Give archive to extract as argument.\\n" && exit
+[ -z "$archive" ] && printf "Give archive to extract as argument.\\n" && exit 1
 
 if [ -f "$archive" ] ; then
 	case "$archive" in


### PR DESCRIPTION
This is a re-attempt of #643 

- `[ "$archive" = "" ]` may be replaced with `[ -z "$archive" ]`
- added exit codes
- upon entering `ext -c` with no arguments stderr will be thrown
from readlink, should be suppressed