### PR TITLE
Improve rotdir script

### DIFF
--- a/.local/bin/rotdir
+++ b/.local/bin/rotdir
@@ -9,4 +9,4 @@
 
 [ -z "$1" ] && echo "usage: rotdir regex 2>&1" && exit 1
 base="$(basename "$1")"
- ls "$PWD" | awk "BEGIN { lines = \"\"; m = 0; } /^$base$/ { m = 1; } { if (!m) { if (lines) { lines = lines\"\n\"; } lines = lines\"\"\$0; } else { print \$0; } } END { print lines; }"
+ls "$PWD" | awk -v BASE="$base" 'BEGIN { lines = ""; m = 0; } { if ($0 == BASE) { m = 1; } } { if (!m) { if (lines) { lines = lines"\n"; } lines = lines""$0; } else { print $0; } } END { print lines; }'


### PR DESCRIPTION
Now doesn't interpret file name as regex pattern.
Since variable expansion is no longer needed, I single-quoted the whole thing and removed escaping backslashes.