### PR TITLE
Add screenlock to suspend/hibernate

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -12,7 +12,7 @@ cmds="\
 🔒 lock		slock
 🚪 leave dwm	kill -TERM $(pidof -s dwm)
 ♻ renew dwm	kill -HUP $(pidof -s dwm)
-🐻 hibernate	${hib:-sudo -A systemctl suspend-then-hibernate}
+🐻 hibernate	slock ${hib:-systemctl suspend-then-hibernate -i}
 🔃 reboot	${reb:-sudo -A reboot}
 🖥 shutdown	${shut:-sudo -A shutdown -h now}"
 


### PR DESCRIPTION
Run slock and pass the command as the argument, which means the system will be
 locked on resume.

`-i` is required for this to work, which works fine on my system however I have
 `NOPASSWD: ALL` in sudoers.