### PR TITLE
Reduce escape delay time in tmux

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -12,6 +12,7 @@ setw -g automatic-rename
 set -g mouse on
 set -g history-limit 30000
 set -g terminal-overrides 'xterm*:smcup@:rmcup@'
+set -sg escape-time 20 # faster escape delay time
 set-option -g status-justify right
 set-option -g status-bg black # colour213 # pink
 set-option -g status-fg cyan


### PR DESCRIPTION
Following https://github.com/LukeSmithxyz/voidrice/issues/800

It was added a configuration to reduce the escape timeout to a lower value in `tmux.conf`.