### PR TITLE
mount exfat for rw

### DIFF
--- a/.local/bin/dmenumount
+++ b/.local/bin/dmenumount
@@ -25,6 +25,7 @@ mountusb() { \
 	partitiontype="$(lsblk -no "fstype" "$chosen")"
 	case "$partitiontype" in
 		"vfat") sudo -A mount -t vfat "$chosen" "$mp" -o rw,umask=0000;;
+		"exfat") sudo -A mount "$chosen" "$mp" -o uid="$(id -u)",gid="$(id -g)";;
 		*) sudo -A mount "$chosen" "$mp"; user="$(whoami)"; ug="$(groups | awk '{print $1}')"; sudo -A chown "$user":"$ug" "$mp";;
 	esac
 	notify-send "💻 USB mounting" "$chosen mounted to $mp."


### PR DESCRIPTION
Exfat does not support user permissions. So using chown on a file inside exfat will always fail.
