### PR TITLE
kill and start only current user's session

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -10,8 +10,8 @@ esac
 
 cmds="\
 🔒 lock		slock
-🚪 leave dwm	kill -TERM $(pidof -s dwm)
-♻ renew dwm	kill -HUP $(pidof -s dwm)
+🚪 leave dwm	kill -TERM $(pgrep -u $USER "\bdwm$")
+♻ renew dwm	kill -HUP $(pgrep -u $USER "\bdwm$")
 🐻 hibernate	${hib:-sudo -A systemctl suspend-then-hibernate}
 🔃 reboot	${reb:-sudo -A reboot}
 🖥 shutdown	${shut:-sudo -A shutdown -h now}"

--- a/.zprofile
+++ b/.zprofile
@@ -131,8 +131,8 @@ ex=🎯:\
 [ ! -f ${XDG_CONFIG_HOME:-$HOME/.config}/shortcutrc ] && shortcuts >/dev/null 2>&1 &
 
 if pacman -Qs libxft-bgra >/dev/null 2>&1; then
-	# Start graphical server on tty1 if not already running.
-	[ "$(tty)" = "/dev/tty1" ] && ! pidof Xorg >/dev/null 2>&1  && exec startx
+	# Start graphical server on user's current tty if not already running.
+	[[ -n "$(tty)" && -z $(pgrep -u $USER "\bXorg$") ]] && exec startx
 else
 	echo "\033[31mIMPORTANT\033[0m: Note that \033[32m\`libxft-bgra\`\033[0m must be installed for this build of dwm.
 Please run:


### PR DESCRIPTION
On systems with multiple users running multiple sessions, it's useful to only kill the current user's Xorg and dwm sessions. This enables simultaneous logins on a single system and kill requests only point at the user's processes.