### PR TITLE
Use Emacs to compile org files

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -49,6 +49,6 @@ case "$ext" in
 	scad) openscad -o "$base".stl "$file" ;;
 	sent) setsid -f sent "$file" 2>/dev/null ;;
 	tex) textype "$file" ;;
-	org) pandoc "$file" --pdf-engine=xelatex -o "$base".pdf ;;
+	org) emacs "$file" --batch -u "$USER" -f org-latex-export-to-pdf ;;
 	*) sed 1q "$file" | grep "^#!/" | sed "s/^#!//" | xargs -r -I % "$file" ;;
 esac


### PR DESCRIPTION
Pandoc is **not** an option for org-modes (#837) since org files are rarely "pure" and often rely on emacs configs or other packages.
Above that many org files use emacs environmental functions/variables that need to be evaluated before compilation.

That being said a xelatex user have his `org-latex-compiler` set to `"xelatex"` so there is no point in including that in the command as well.
Or if the org author sees fit can include that variable in the org file (in the very crucial part that is ignored by pandoc).

