### PR TITLE
read command fix

### DIFF
--- a/.local/bin/statusbar/popupgrade
+++ b/.local/bin/statusbar/popupgrade
@@ -6,4 +6,4 @@ yay -Syu
 pkill -RTMIN+8 "${STATUSBAR:-dwmblocks}"
 
 printf "\\nUpgrade complete.\\nPress <Enter> to exit window.\\n\\n"
-read -r
+read -r _


### PR DESCRIPTION
Fixes #847 

> since the variable is not being used again, "_" wil suffice, "line" as the name would also be valid.

Graphical explanation:

![pic-selected-201123-1557-20](https://user-images.githubusercontent.com/51257127/100014600-97d2e780-2da4-11eb-99de-1a2490ea9d84.png)
