### PR TITLE
Add drag-and-drop command to lfrc

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -63,6 +63,8 @@ cmd copyto ${{
 cmd setbg "$1"
 cmd bulkrename $vidir
 
+cmd draganddrop &dragon-drag-and-drop -a -x $fx
+
 # Bindings
 map <c-f> $lf -remote "send $id select '$(fzf)'"
 map J $lf -remote "send $id cd $(cut -d'	' -f2 ${XDG_CONFIG_HOME:-$HOME/.config}/directories | fzf)"
@@ -78,6 +80,7 @@ map x $$f
 map X !$f
 map o &mimeopen $f
 map O $mimeopen --ask $f
+map dr draganddrop
 
 map A rename # at the very end
 map c push A<c-u> # new rename


### PR DESCRIPTION
Adds a command called `draganddrop` in `lf(1)` which calls `dragon-drag-and-drop(1)` to allow "drag-and-drop"-ing files from `lf(1)` to other GUI applications. This command is then mapped to `dr`.

Use it in `lf(1)` by pressing `dr` to drag-and-drop the currently highlighted file, or select multiple files then press `dr` to drag-and-drop all of them at once.