### PR TITLE
Compatibility for FreeBSD's paste(1)

### DIFF
--- a/.config/shell/profile
+++ b/.config/shell/profile
@@ -6,7 +6,7 @@
 # to clean up.
 
 # Adds `~/.local/bin` to $PATH
-export PATH="$PATH:$(du "$HOME/.local/bin" | cut -f2 | paste -sd ':')"
+export PATH="$PATH:$(du "$HOME/.local/bin" | cut -f2 | paste -sd ':' -)"
 
 unsetopt PROMPT_SP
 

--- a/.local/bin/displayselect
+++ b/.local/bin/displayselect
@@ -53,7 +53,7 @@ multimon() { # Multi-monitor handler.
 	esac ;}
 
 onescreen() { # If only one output available or chosen.
-	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ')
+	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ' -)
 	}
 
 postrun() { # Stuff to run to clean up.

--- a/.local/bin/statusbar/music
+++ b/.local/bin/statusbar/music
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | paste -sd ' ';}
+filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | paste -sd ' ' -;}
 
 pidof -x mpdup >/dev/null 2>&1 || mpdup >/dev/null 2>&1 &
 

--- a/.local/bin/statusbar/torrent
+++ b/.local/bin/statusbar/torrent
@@ -8,7 +8,7 @@ transmission-remote -l | grep % |
 	s/.*Idle.*/B 🕰️/;
 	s/.*Uploading.*/L ⬆️/;
 	s/.*%.*/M ⬇️/" |
-		sort -h | uniq -c | awk '{print $3 $1}' | paste -sd ' '
+		sort -h | uniq -c | awk '{print $3 $1}' | paste -sd ' ' -
 
 case $BLOCK_BUTTON in
 	1) setsid -f "$TERMINAL" -e tremc ;;


### PR DESCRIPTION
According to FreeBSD's [paste(1)](https://www.freebsd.org/cgi/man.cgi?query=paste&sektion=1&manpath=FreeBSD+12.2-RELEASE+and+Ports), the extra `-` is needed (tested by myself).
This obviously works for Linux as well, tested on Void Linux at least.

> Create a colon-separated list of directories named bin, suitable for use in the PATH environment variable:

`find / -name bin -type d | paste -s -d : -`