### PR TITLE
Added Java support for compiler script

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -34,6 +34,7 @@ case "$ext" in
 	cs) mcs "$file" && mono "$base".exe ;;
 	go) go run "$file" ;;
 	h) sudo make install ;;
+	java) javac -d classes "$file" && java -cp classes "${1%.*}" ;;
 	m) octave "$file" ;;
 	md)	if  [ -x "$(command -v lowdown)" ]; then
 			lowdown -d nointem -e super "$file" -Tms | groff -mpdfmark -ms -kept > "$base".pdf


### PR DESCRIPTION
Tested it on a project with this structure:

```
- root
 |- test
    | - Test.java
```

The user must call `compiler` from the root of the project, but that should not
be an inconvenience because usually the working directory is the project's
root. Nonetheless, it also works for java files in the current working directory,
in case someone just wants to test some code quickly.