### PR TITLE
Fixed edp1 botching dp1 grep

### DIFF
--- a/.local/bin/displayselect
+++ b/.local/bin/displayselect
@@ -53,7 +53,7 @@ multimon() { # Multi-monitor handler.
 	esac ;}
 
 onescreen() { # If only one output available or chosen.
-	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ' -)
+	xrandr --output "$1" --auto --scale 1.0x1.0 $(echo "$allposs" | grep -v "\b$1" | awk '{print "--output", $1, "--off"}' | paste -sd ' ' -)
 	}
 
 postrun() { # Stuff to run to clean up.


### PR DESCRIPTION
Using displayselect to select a single external display connected via display port (nb: you won't be able to recreate with a DP->HDMI converter, only DP->Monitor) will result in nothing happening. This is because the primary display is given in xrandr as eDP1, and the external display port as DP1. 