### PR TITLE
Improve the dwmblocks clock script to update at exactly 00 seconds each minute.

### DIFF
--- a/.local/bin/statusbar/clock
+++ b/.local/bin/statusbar/clock
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Refresh clock at exactly 00 seconds
+refresh(){
+    sleep $((60-$(date "+%S")))
+    kill -35 $(pidof dwmblocks)
+}
+
 clock=$(date '+%I')
 
 case "$clock" in
@@ -27,3 +33,4 @@ case $BLOCK_BUTTON in
 esac
 
 date "+%Y %b %d (%a) $icon%I:%M%p"
+refresh &


### PR DESCRIPTION
After execution script schedules refresh at exactly 00 seconds.
Update interval in dwmblocks/config.h has to be 0. Update Signal assumed to be 1, as it is.
`
...
{"",	"clock",	0,	1},
...
`