### PR TITLE
adopting `sb-`

### DIFF
--- a/.local/bin/statusbar/sb-music
+++ b/.local/bin/statusbar/sb-music
@@ -2,7 +2,7 @@
 
 filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | paste -sd ' ' -;}
 
-pidof -x mpdup >/dev/null 2>&1 || mpdup >/dev/null 2>&1 &
+pidof -x sb-mpdup >/dev/null 2>&1 || sb-mpdup >/dev/null 2>&1 &
 
 case $BLOCK_BUTTON in
 	1) mpc status | filter ; setsid -f "$TERMINAL" -e ncmpcpp ;;  # right click, pause/unpause

--- a/.local/bin/statusbar/sb-pacpackages
+++ b/.local/bin/statusbar/sb-pacpackages
@@ -18,7 +18,7 @@
 # Exec = /usr/bin/pkill -RTMIN+8 dwmblocks # Or i3blocks if using i3.
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e popupgrade ;;
+	1) setsid -f "$TERMINAL" -e sb-popupgrade ;;
 	2) notify-send "$(/usr/bin/pacman -Qu)" ;;
 	3) notify-send "🎁 Upgrade module" "📦: number of upgradable packages
 - Left click to upgrade packages


### PR DESCRIPTION
The 2619a88fcd94cbd4b2caa719ba926ae0013fb4ec update might have broken scripts, like this, that use a script from `~sc/statusbar/`