### PR TITLE
Use find instead du for more efficient execution.

### DIFF
--- a/.config/shell/profile
+++ b/.config/shell/profile
@@ -6,7 +6,7 @@
 # to clean up.
 
 # Adds `~/.local/bin` to $PATH
-export PATH="$PATH:$(du "$HOME/.local/bin" | cut -f2 | paste -sd ':' -)"
+export PATH="$PATH:${$(find ~/.local/bin -type d -printf %p:)%%:}"
 
 unsetopt PROMPT_SP
 


### PR DESCRIPTION
Find is faster and it is only one command. The last `:` is removed by the parameter expansion (works in both Bash and Zsh).