### PR TITLE
Leave a single newline if reducing trailing in init.vim

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -113,7 +113,7 @@ set noshowcmd
 
 " Automatically deletes all trailing whitespace and newlines at end of file on save.
 	autocmd BufWritePre * %s/\s\+$//e
-	autocmd BufWritePre * %s/\n\+\%$//e
+	autocmd BufWritePre * %s/\n\+\%$/\n/e
 
 " When shortcut files are updated, renew bash and ranger configs with new material:
 	autocmd BufWritePost bm-files,bm-dirs !shortcuts


### PR DESCRIPTION
While removing trailing newlines is a good idea, it is a problem when
editing C files which "must" have an empty line at the bottom.

So we leave just a single newline, if there were any.