### PR TITLE
Leave a single newline if reducing trailing (C files)

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -113,7 +113,8 @@ set noshowcmd
 
 " Automatically deletes all trailing whitespace and newlines at end of file on save.
 	autocmd BufWritePre * %s/\s\+$//e
-	autocmd BufWritePre * %s/\n\+\%$//e
+    autocmd BufWritePre * %s/\n\+\%$//e
+    autocmd BufWritePre *.[ch] %s/\%$/\r/e
 
 " When shortcut files are updated, renew bash and ranger configs with new material:
 	autocmd BufWritePost bm-files,bm-dirs !shortcuts


### PR DESCRIPTION
While removing trailing newlines is a good idea, it is a problem when
editing C files which "must" have an empty line at the bottom.

Tested a .c and non-.c file.

Works by deleting all the lines then adding just one to C programs.

http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
5.1.1.2 #2

    A source file that is not empty shall end in a new-line
    character,which
    shall not be immediately preceded by a backslash character before
    any such splicing takes place.
