### PR TITLE
Put find output in a separate variable

### DIFF
--- a/.config/shell/profile
+++ b/.config/shell/profile
@@ -6,8 +6,10 @@
 # to clean up.
 
 # Adds `~/.local/bin` to $PATH
-export PATH="$PATH:${$(find ~/.local/bin -type d -printf %p:)%%:}"
+LOC=$(find ~/.local/bin -type d -printf %p:)
+export PATH="$PATH:${LOC%%:}"
 
+unset LOC
 unsetopt PROMPT_SP
 
 # Default programs:


### PR DESCRIPTION
It turned out that it did not work in one go (it complained about not possible substitution). 
When using separate LOC variable it did work.