### PR TITLE
File naming for links longer than 255 chars

### DIFF
--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -13,9 +13,9 @@ case "$1" in
 	*mkv|*webm|*mp4|*youtube.com/watch*|*youtube.com/playlist*|*youtu.be*|*hooktube.com*|*bitchute.com*|*videos.lukesmith.xyz*)
 		setsid -f mpv -quiet "$1" >/dev/null 2>&1 ;;
 	*png|*jpg|*jpe|*jpeg|*gif)
-		curl -sL "$1" > "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
+		curl -sL "$1" > "/tmp/$(echo "${1:0:255}.${1##*.}" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "${1:0:255}.${1##*.}" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
 	*pdf|*cbz|*cbr)
-		curl -sL "$1" > "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$1" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
+		curl -sL "$1" > "/tmp/$(echo "${1:0:255}.${1##*.}" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "${1:0:255}.${1##*.}" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
 	*mp3|*flac|*opus|*mp3?source*)
 		qndl "$1" 'curl -LO'  >/dev/null 2>&1 ;;
 	*)


### PR DESCRIPTION
While creating a file based on link longer than 255 characters we'll encounter `File name too long` error.  This workaround forms a filename by keeping first 255 characters and concatenates them with file extention.