### PR TITLE
`rssadd` improvement: additionally extract from xml files, not just urls

### DIFF
--- a/.local/bin/rssadd
+++ b/.local/bin/rssadd
@@ -8,8 +8,7 @@ else
 		sed -E 's_^.*href="(https?://[^"]+)".*$_\1_')"
 
 	! grep "https*://\S\+\.[A-Za-z]\+\S*" <<<"$url" &&
-		notify-send "That doesn't look like a full URL." && exit
-		exit 1
+		notify-send "That doesn't look like a full URL." && exit 1
 fi
 
 RSSFILE="${XDG_CONFIG_HOME:-$HOME/.config}/newsboat/urls"

--- a/.local/bin/rssadd
+++ b/.local/bin/rssadd
@@ -1,10 +1,20 @@
 #!/bin/sh
 
-! echo "$1" | grep "https*://\S\+\.[A-Za-z]\+\S*" >/dev/null &&
-	notify-send "That doesn't look like a full URL." && exit
+if echo "$1" | grep "https*://\S\+\.[A-Za-z]\+\S*" >/dev/null; then
+	url="$1"
+else
+	url="$(grep 'rel="self"' "$1" |
+		grep xml |
+		sed -E 's_^.*href="(https?://[^"]+)".*$_\1_')"
+
+	! grep "https*://\S\+\.[A-Za-z]\+\S*" <<<"$url" &&
+		notify-send "That doesn't look like a full URL." && exit
+		exit 1
+fi
+
 RSSFILE="${XDG_CONFIG_HOME:-$HOME/.config}/newsboat/urls"
-if awk '{print $1}' "$RSSFILE" | grep "^$1$" >/dev/null; then
+if awk '{print $1}' "$RSSFILE" | grep "^$url$" >/dev/null; then
 	notify-send "You already have this RSS feed."
 else
-	echo "$1" >> "$RSSFILE" && notify-send "RSS feed added."
+	echo "$url" >> "$RSSFILE" && notify-send "RSS feed added."
 fi

--- a/.local/bin/rssadd
+++ b/.local/bin/rssadd
@@ -3,8 +3,7 @@
 if echo "$1" | grep "https*://\S\+\.[A-Za-z]\+\S*" >/dev/null; then
 	url="$1"
 else
-	url="$(grep 'rel="self"' "$1" |
-		grep xml |
+	url="$(grep -Eom1 '<[^>]+(rel="self"|application/[a-z]+\+xml)[^>]+>' "$1" |
 		sed -E 's_^.*href="(https?://[^"]+)".*$_\1_')"
 
 	! grep "https*://\S\+\.[A-Za-z]\+\S*" <<<"$url" &&


### PR DESCRIPTION
Before this, rssadd only accepted a URL as argument. Now, if given
an xml file, it will parse it and extract the proper url. This lets it
be used in conjunction with firefox for quickly adding RSS feeds (as
firefox would give it the file rather than its origin URL). This works
on a majority of RSS feeds, but fails on some that miss the proper link
tags. The original behaviour is still mantained alongside the new.