### PR TITLE
Add keybord toggle option which needs a shortcut in dwm config

### DIFF
--- a/.local/bin/statusbar/sb-kbselect
+++ b/.local/bin/statusbar/sb-kbselect
@@ -1,11 +1,28 @@
 #!/bin/sh
 # works on any init system
 # requirements: dmenu, xorg-setxkbmap
+# Using "," as the separator set your default layouts in $HOME/.local/share/xkb-layouts
+kbselect() {\
+	kb_choice="$(awk '/! layout/{flag=1; next} /! variant/{flag=0} flag {print $2, "- " $1}' /usr/share/X11/xkb/rules/base.lst | dmenu -l 15)"
+	kb="$(echo "$kb_choice" | awk '{print $3}')"
+	}
+
+defaults="${XDG_DATA_HOME:-$HOME/.local/share}/xkb-layouts"
 kb="$(setxkbmap -query | grep -oP 'layout:\s*\K\w+')" || exit 1
 
+[ -f "$defaults" ] || printf "us" > "$defaults"
+
+case $1 in
+	add) kbselect
+	grep "$kb" "$defaults" || sed -i "s/$/,$kb/" "$defaults" ;;
+	toggle) kb=$(grep -o "$kb.*" "$defaults" | awk -F, '{print $2}')
+	[ "$kb" = "" ] && kb=$(cut -f1 -d',' "$defaults")
+	setxkbmap "$kb" ;;
+esac
+
+
 case $BLOCK_BUTTON in
-	1) kb_choice="$(awk '/! layout/{flag=1; next} /! variant/{flag=0} flag {print $2, "- " $1}' /usr/share/X11/xkb/rules/base.lst | dmenu -l 15)"
-	kb="$(echo "$kb_choice" | awk '{print $3}')"
+	1) kbselect 
 	setxkbmap "$kb"
 	pkill -RTMIN+30 "${STATUSBAR:-dwmblocks}";;
 	3) notify-send "⌨  Keyboard/language module" "$(printf "%s" "\- Current layout: $(setxkbmap -query | grep -oP 'layout:\s*\K\w+')")


### PR DESCRIPTION
[Here](https://github.com/LukeSmithxyz/dwm/pull/150)  is the `shortcut in dwm` pull request.
You can use the setxkbmap to set the default layouts  `setxkbmap -layout us,ir -option "grp:shifts_toggle,caps:escape_shifted_capslock,altwin:menu_win"` which I'm using right now in [my `.xprofile`](https://github.com/mhdzli/dotfiles/blob/master/src/.xprofile#L13),  but then you can't get the current layout using `setxkbmap`.
There is some tools that can get the current layout in this case: like `xkb-switch` and `xkb-state` .
I use [this `C` code](https://gist.github.com/mhdzli/bd017f698354ace4b788e5db8d0b7f7c) to get the current layout. You can get the compiled file from [here](https://github.com/mhdzli/dotfiles/blob/master/src/.local/bin/statusbar/sb-xkbl) or add this to `dwmblocks` as  xkb module.
And the `remaps` script also needs some changes to match the setxkpmap default options as in [here](https://github.com/mhdzli/dotfiles/blob/master/src/.local/bin/remaps#L5)