### PR TITLE
Encrypted connection to Luke's RSS feed

### DIFF
--- a/.config/newsboat/urls
+++ b/.config/newsboat/urls
@@ -1,4 +1,4 @@
-http://lukesmith.xyz/rss.xml
+https://lukesmith.xyz/rss.xml
 https://notrelated.libsyn.com/rss
 https://www.youtube.com/feeds/videos.xml?channel_id=UC2eYFnH61tmytImy1mTYvhA "~Luke Smith (YouTube)"
 https://www.archlinux.org/feeds/news/ "tech"


### PR DESCRIPTION
There is no reason for the URL of Luke's main RSS feed to be transferred over unencrypted HTTP. That's why i changed it to HTTPS. Nothing big, it just mildly infuriated me.