### PR TITLE
Prevent unnecessary caching of tsp output

### DIFF
--- a/.local/bin/statusbar/sb-tasks
+++ b/.local/bin/statusbar/sb-tasks
@@ -2,24 +2,19 @@
 
 # Originally by Andr3as07 <https://github.com/Andr3as07>
 # Some changes by Luke
+# Rebuild by Tenyun
 
 # This block displays the number running background tasks.  Requires tsp.
 
-tspout="$(tsp -l)"
+num=$(tsp -l | awk -v numr=0 -v numq=0 '{if (/running/)numr++; if (/queued/)numq++} END{print numr+numq"("numq")"}')
 
 # Handle mouse clicks
 case $BLOCK_BUTTON in
-	1) echo "$tspout" > "${XDG_CACHE_HOME:-$HOME/.cache}/tspout"
-		setsid -f "$TERMINAL" -e less "${XDG_CACHE_HOME:-$HOME/.cache}/tspout" ;;
+	1) setsid -f "$TERMINAL" -e tsp -l ;;
 	3) notify-send "Tasks module" "🤖: number of running/queued background tasks
 - Left click opens tsp" ;; # Right click
 	2) $EDITOR "$0" ;; # Middle click
 esac
 
-numr=$(echo "$tspout" | grep -c "running")
-numq=$(echo "$tspout" | grep -c "queued")
-
-num=$((numr + numq))
-
-[ "$num" -gt 0 ] &&
-   echo "🤖$num($numq)"
+[ "$num" != "0(0)" ] &&
+	echo "🤖$num"


### PR DESCRIPTION
I think it is not necessary to store the output of tsp in a temporary file. 
All necessary operations can be performed during runtime.