### PR TITLE
read ignore path from /etc/fstab

### DIFF
--- a/.local/bin/dmenuumount
+++ b/.local/bin/dmenuumount
@@ -26,7 +26,8 @@ asktype() { \
 	esac
 	}
 
-drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$4!~/\/boot|\/home$|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
+ignores=$(echo $(grep UUID /etc/fstab | awk '$3 !~ /swap|this/ { print $2 }') | sed 's/ /$|^/g' | sed 's/\//\\\//g')
+drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$4!~/^'$ignores'$'$(which snap >/dev/null 2>&1 && echo "|\\/snap")'|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
 
 if ! grep simple-mtpfs /etc/mtab; then
 	[ -z "$drives" ] && echo "No drives to unmount." &&  exit


### PR DESCRIPTION
For different disk settings, reading the configuration path from `/etc/fstab` seems to be a good idea.
Just like me, I usually create another disk part and mount it on `/var/lib/docker` to store my docker image.
When I execute the script, the path `/var/lib/docker` will be displayed in the options.
Another problem for ubuntu users is that the `snap` daemon will install something in the `/snap` folder, and I will also ignore it.
Read settings from `/etc/fstab` can be better used in various system environments.
