### PR TITLE
Add support for multiple batteries

### DIFF
--- a/.local/bin/statusbar/sb-battery
+++ b/.local/bin/statusbar/sb-battery
@@ -20,6 +20,8 @@ esac
 [ ! -e /sys/class/power_supply/BAT?* ] && echo "No battery found" && exit 1
 
 # Loop through all attached batteries and format the info
+
+STATUS=""
 for battery in /sys/class/power_supply/BAT?*
 do
 	# Sets up the status and capacity
@@ -29,11 +31,15 @@ do
 		"Discharging") status="🔋" ;;
 		"Charging") status="🔌" ;;
 		"Not charging") status="🛑" ;;
-		"Unknown") status="♻️" ;;
+		"Unknown") status="🔋❓" ;;
 	esac
 	capacity=$(cat "$battery/capacity")
 	# Will make a warn variable if discharging and low
 	[ "$status" = "🔋" ] && [ "$capacity" -le 25 ] && warn="❗"
 	# Prints the info
-	printf "%s%s%d%%\n" "$status" "$warn" "$capacity"; unset warn
-done && return 0
+	TEMP=""
+	printf -v TEMP "%s%s%d%%" "$status" "$warn" "$capacity"; unset warn
+	STATUS="$STATUS $TEMP"
+done
+echo "$STATUS"
+return 0


### PR DESCRIPTION
Hello, I have a laptop with two batteries and I want to display them both. Your script has support for 2 batteries in theory, i.e. it prints two strings with status. But only the first result is used. I propose concatenating two results in one string and echoing *it* instead. That way 2 batteries are displayed inside one dwm block. Also there was a bug when a square symbol was displayed after the  recycle icon. I replaced it with a different emoji.