### PR TITLE
Use g instead of gg in zathura

### DIFF
--- a/.config/zathura/zathurarc
+++ b/.config/zathura/zathurarc
@@ -12,3 +12,4 @@ map K zoom in
 map J zoom out
 map i recolor
 map p print
+map g goto top


### PR DESCRIPTION
Since no other key binding starts with g, it makes more sense to use g instead of gg to go to the first page. This change also allows the use of ng to go to the nth page (instead of nG or ngg).