### PR TITLE
Add `Braille` font family to `monospace` @ fontconfig

### DIFF
--- a/.config/fontconfig/fonts.conf
+++ b/.config/fontconfig/fonts.conf
@@ -30,6 +30,7 @@
 		<prefer>
 			<family>Noto Sans Mono</family>
 			<family>Liberation Mono</family>
+			<family>Braille</family>
 		</prefer>
 	</alias>
 </fontconfig>


### PR DESCRIPTION
Some programs like `gotop` [1] or `bottom` / `btm` [2] weren't displaying properly in `st` (though e.g. `alacritty` worked by default, and I tried switching, but that's just not gonna happen:D), and I was able to fix the glyphs with the Braille font (don't recall where I found the recommendation, perhaps [3]).

needs `ttf-ubraille` [4] so an update in LARBS progs.csv would be needed aswell.

Don't forget to 

```sh
fc-cache -fv --really-force
```

Also beware of stuff like [5].

[1] https://aur.archlinux.org/packages/gotop
[2] https://aur.archlinux.org/packages/bottom-bin
[3] https://github.com/kovidgoyal/kitty/issues/1623, https://github.com/cjbassi/gotop/issues/18#issuecomment-637271051 and others
[4] https://aur.archlinux.org/packages/ttf-ubraille
[5]  https://wiki.archlinux.org/index.php/Font_configuration#Disable_scaling_of_bitmap_fonts