### PR TITLE
Deleted the .xinitrc link at $HOME for even a cleaner home directory.

### DIFF
--- a/.config/shell/profile
+++ b/.config/shell/profile
@@ -19,7 +19,7 @@ export BROWSER="brave"
 export XDG_CONFIG_HOME="$HOME/.config"
 export XDG_DATA_HOME="$HOME/.local/share"
 export XDG_CACHE_HOME="$HOME/.cache"
-#export XINITRC="${XDG_CONFIG_HOME:-$HOME/.config}/x11/xinitrc"
+export XINITRC="${XDG_CONFIG_HOME:-$HOME/.config}/x11/xinitrc"
 #export XAUTHORITY="$XDG_RUNTIME_DIR/Xauthority" # This line will break some DMs.
 export NOTMUCH_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/notmuch-config"
 export GTK2_RC_FILES="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-2.0/gtkrc-2.0"
@@ -142,7 +142,7 @@ ex=🎯:\
 
 if pacman -Qs libxft-bgra >/dev/null 2>&1; then
 	# Start graphical server on user's current tty if not already running.
-	[ "$(tty)" = "/dev/tty1" ] && ! pidof -s Xorg >/dev/null 2>&1 && exec startx
+	[ "$(tty)" = "/dev/tty1" ] && ! pidof -s Xorg >/dev/null 2>&1 && exec startx $XINITRC
 else
 	echo "\033[31mIMPORTANT\033[0m: Note that \033[32m\`libxft-bgra\`\033[0m must be installed for this build of dwm.
 Please run:

--- a/.xinitrc
+++ b/.xinitrc
@@ -1,1 +1,0 @@
-.config/x11/xinitrc


### PR DESCRIPTION
A custom filename and directory can be specified with startx command,
which in this case is $XINITRC variable that indicates
$XDG_CONFIG_HOME/x11/xinitrc

I realized there was already and $XINITRC variable that is commented out, I don't know if what I am suggesting was done before and decided it was not preferable for some reason. But I am making the pull request anyway in case it is useful.