### PR TITLE
fix sb-forecast

### DIFF
--- a/.local/bin/statusbar/sb-forecast
+++ b/.local/bin/statusbar/sb-forecast
@@ -6,6 +6,7 @@
 # If we have internet, get a weather report from wttr.in and store it locally.
 # You could set up a shell alias to view the full file in a pager in the
 # terminal if desired. This function will only be run once a day when needed.
+LOCATION=''
 weatherreport="${XDG_DATA_HOME:-$HOME/.local/share}/weatherreport"
 getforecast() { curl -sf "wttr.in/$LOCATION" > "$weatherreport" || exit 1 ;}
 
@@ -14,7 +15,7 @@ getforecast() { curl -sf "wttr.in/$LOCATION" > "$weatherreport" || exit 1 ;}
 # display them with coresponding emojis.
 showweather() { printf "%s" "$(sed '16q;d' "$weatherreport" |
 	grep -wo "[0-9]*%" | sort -rn | sed "s/^/☔/g;1q" | tr -d '\n')"
-sed '13q;d' "$weatherreport" | grep -o "m\\([-+]\\)*[0-9]\\+" | sort -n -t 'm' -k 2n | sed -e 1b -e '$!d' | tr '\n|m' ' ' | awk '{print " 🥶" $1 "°","🌞" $2 "°"}' ;}
+sed '13q;d' "$weatherreport" | grep -o "m\\([-+]\\)*[0-9]\\+" | sed 's/+//g' | sort -n -t 'm' -k 2n | sed -e 1b -e '$!d' | tr '\n|m' ' ' | awk '{print " 🥶" $1 "°","🌞" $2 "°"}' ;}
 
 case $BLOCK_BUTTON in
 	1) setsid -f "$TERMINAL" -e less -Srf "$weatherreport" ;;


### PR DESCRIPTION
The source of problems is the `+` sign. It wont allow to sort numbers how we like.

### Here is a template with problems: https://pastebin.com/raw/bneay3wW
#### it should outout `☔0% 🥶1° 🌞10°` , but it outputs: `☔0% 🥶+10° 🌞8°`

----
# Explanation:
Lets say we have these:
```bash
echo "m1\nm9\nm10\nm11\nm+99\nm+100\nm+101\nm-1\nm-9\nm-10\nm-11"
```
What we **want** as end result  is :
```
m-11
m-10
m-9
m-1
m1
m9
m10
m11
m99
m100
m101
```
Because we will sed out the first (coldest) and last (hotest) line.
Though what we will get without using `sed 's/+//g'` before the sort command in the pipe, is this:
```
m-11
m-10
m-9
m-1
m+100
m+101
m+99
m1
m9
m10
m11
```
The numbers which had a `+` are sorted before, so putting them in the middle.