### PR TITLE
Add a paru support in sb-popupgrade

### DIFF
--- a/.local/bin/statusbar/sb-popupgrade
+++ b/.local/bin/statusbar/sb-popupgrade
@@ -2,7 +2,12 @@
 
 printf "Beginning upgrade.\\n"
 
-yay -Syu
+if ! command -v paru &> /dev/null; then
+    yay -Syu
+else
+    paru -Syu
+fi
+
 pkill -RTMIN+8 "${STATUSBAR:-dwmblocks}"
 
 printf "\\nUpgrade complete.\\nPress <Enter> to exit window.\\n\\n"


### PR DESCRIPTION
**Adds simple conditional statement which is checking if user has the paru AUR manager.**

As we all know yay is not as well maintained as in the past and many people have moved to paru. For this reason I made this commit. Of course, if the user hasn't got paru, the script will still use yay.