### PR TITLE
Improve handling of pulseaudio

### DIFF
--- a/.asoundrc
+++ b/.asoundrc
@@ -1,0 +1,1 @@
+.config/alsa/asoundrc

--- a/.config/alsa/asoundrc
+++ b/.config/alsa/asoundrc
@@ -1,0 +1,2 @@
+pcm.default pulse
+ctl.default pulse

--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -11,10 +11,3 @@ xcompmgr &		# xcompmgr for transparency
 dunst &			# dunst for notifications
 xset r rate 300 50 &	# Speed xrate up
 unclutter &		# Remove mouse when idle
-
-# This line autostarts an instance of Pulseaudio that does not exit on idle.
-# This is "necessary" on Artix due to a current bug between PA and
-# Chromium-based browsers where they fail to start PA and use dummy output.
-pidof -s runit &&
-	! pidof -s pulseaudio >/dev/null 2>&1 &&
-	setsid -f pulseaudio --start --exit-idle-time=-1 >/dev/null 2>&1


### PR DESCRIPTION
Hello,

I currently am using pulseaudio on a minimal setup of artix linux with dwm similar to your dotfiles.
I was always having issues with pulseaudio: it either wouldn't start correctly, would crash, or would spike at 100 percent cpu usage at startup. Reading through your closed issues it seems people are still experiencing these issues, and a solution that covers all cases has not been found.

A while back I was investigating how to start pulseaudio with brave browser and came across the simple, minimal solution that has truly fixed all my audio problems by adding 2 lines to the asoundrc file in my home directory. It basically makes pulseaudio the default audio device for alsa. Since then, I have never had any issues with pulseaudio: it has always started automatically and I don't need to make it the default audio device on a per-application basis.

I have forked the repository and already commited the changes for you to review and hopefully merge into master. Please reply to this if you have any questions.