### PR TITLE
Specified shutdown time (0 seconds) for openrc shutdown option

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -5,7 +5,7 @@
 # For non-systemd init systems.
 case "$(readlink -f /sbin/init)" in
 	*runit*) hib="sudo -A zzz" ;;
-	*openrc*) reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p" ;;
+	*openrc*) reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p 0" ;;
 esac
 
 cmds="\


### PR DESCRIPTION
If you don't specify it, it won't work:
$ sudo -A openrc-shutdown -p
 * openrc-shutdown: No shutdown time specified