### PR TITLE
newsboat: fix non-posix here-string for clipboard macro

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -36,7 +36,7 @@ macro a set browser "tsp youtube-dl --add-metadata -xic -f bestaudio/best" ; ope
 macro v set browser "setsid -f mpv" ; open-in-browser ; set browser linkhandler
 macro w set browser "lynx" ; open-in-browser ; set browser linkhandler
 macro d set browser "dmenuhandler" ; open-in-browser ; set browser linkhandler
-macro c set browser "xsel -b <<<" ; open-in-browser ; set browser linkhandler
+macro c set browser "echo %u | xclip -r -sel c" ; open-in-browser ; set browser linkhandler
 macro C set browser "youtube-viewer --comments=%u" ; open-in-browser ; set browser linkhandler
 macro p set browser "peertubetorrent %u 480" ; open-in-browser ; set browser linkhandler
 macro P set browser "peertubetorrent %u 1080" ; open-in-browser ; set browser linkhandler


### PR DESCRIPTION
Fixes #921. Previously, the `,c` macro would not work for users with `dash` as `/bin/sh`.