### PR TITLE
for passmenu to use gtk3 box

### DIFF
--- a/pinentry/preexec
+++ b/pinentry/preexec
@@ -1,0 +1,5 @@
+#!/hint/sh
+
+# Define additional functionality for pinentry. For example
+test -e /usr/lib/libgcr-base-3.so.1 && exec /usr/bin/pinentry-gnome3 "$@"
+#test -e /usr/lib/libQt5Widgets.so.5 && exec /usr/bin/pinentry-qt     "$@"


### PR DESCRIPTION
thanks to the `pinentry` package, it uses gtk2 auth. box, or if you don't have gtk2, uses cli/curses box, **in the background**, so it makes passmenu, unusable.
The file originates from `/etc/pinentry/preexec`.