### PR TITLE
Small improvements to power actions script

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -5,6 +5,7 @@
 # For systemd-based systems.
 case "$(readlink -f /sbin/init)" in
 	*systemd*)
+	slp="systemctl suspend -i"
 	hib="systemctl suspend-then-hibernate -i"
 	shut="systemctl poweroff -i"
 	reb="systemctl reboot -i";;
@@ -14,6 +15,7 @@ cmds="\
 🔒 lock		slock
 🚪 leave dwm	kill -TERM $(pgrep -u $USER "\bdwm$")
 ♻ renew dwm	kill -HUP $(pgrep -u $USER "\bdwm$")
+💤 sleep	slock ${slp:-loginctl suspend -i}
 🐻 hibernate	slock ${hib:-loginctl suspend-then-hibernate -i}
 🔃 reboot	${reb:-loginctl reboot -i}
 🖥 shutdow	${shut:-systemctl poweroff -i}

--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -2,19 +2,21 @@
 
 # A dmenu wrapper script for system functions.
 
-# For non-systemd init systems.
+# For systemd-based systems.
 case "$(readlink -f /sbin/init)" in
-	*runit*) hib="sudo -A zzz" ;;
-	*openrc*) reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p 0" ;;
+	*systemd*)
+	hib="systemctl suspend-then-hibernate -i"
+	shut="systemctl poweroff -i"
+	reb="systemctl reboot -i";;
 esac
 
 cmds="\
 🔒 lock		slock
 🚪 leave dwm	kill -TERM $(pgrep -u $USER "\bdwm$")
 ♻ renew dwm	kill -HUP $(pgrep -u $USER "\bdwm$")
-🐻 hibernate	slock ${hib:-systemctl suspend-then-hibernate -i}
-🔃 reboot	${reb:-sudo -A reboot}
-🖥 shutdown	${shut:-sudo -A shutdown -h now}
+🐻 hibernate	slock ${hib:-loginctl suspend-then-hibernate -i}
+🔃 reboot	${reb:-loginctl reboot -i}
+🖥 shutdow	${shut:-systemctl poweroff -i}
 📺 display off 	 xset dpms force off"
 
 choice="$(echo "$cmds" | cut -d'	' -f 1 | dmenu)" || exit 1


### PR DESCRIPTION
I've swapped out the commands used to manage power which require root privileges for ones which either do not or can be configured as such. If SystemD is detected, the script uses `systemctl` to manage power. If not, it uses a feature of `elogind` (used on Artix) to do power actions without requiring superuser (`loginctl`).

I also added a new option to put the system to sleep, rather than hibernate. The kernel will refuse to use the sleep then hibernate option if you don't have much swap or have it disabled.