### PR TITLE
Fixed/improved power action script (done properly this time)

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -4,7 +4,7 @@
 
 # For non-systemd init systems.
 case "$(readlink -f /sbin/init)" in
-	*runit*) hib="sudo -A zzz" ;;
+	*runit*) slp="sudo -A zzz -z"; hib="sudo -A zzz -Z" ;;
 	*openrc*) reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p 0" ;;
 esac
 
@@ -12,7 +12,8 @@ cmds="\
 🔒 lock		slock
 🚪 leave dwm	kill -TERM $(pgrep -u $USER "\bdwm$")
 ♻ renew dwm	kill -HUP $(pgrep -u $USER "\bdwm$")
-🐻 hibernate	slock ${hib:-systemctl suspend-then-hibernate -i}
+💤 sleep	slock ${slp:-systemctl suspend -i}
+🐻 hibernate	slock ${hib:-systemctl hibernate -i}
 🔃 reboot	${reb:-sudo -A reboot}
 🖥 shutdown	${shut:-sudo -A shutdown -h now}
 📺 display off 	 xset dpms force off"

--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -12,8 +12,8 @@ cmds="\
 🔒 lock		slock
 🚪 leave dwm	kill -TERM $(pgrep -u $USER "\bdwm$")
 ♻ renew dwm	kill -HUP $(pgrep -u $USER "\bdwm$")
-💤 sleep	slock ${slp:-systemctl suspend -i}
-🐻 hibernate	slock ${hib:-systemctl hibernate -i}
+💤 sleep	${slp:-systemctl suspend -i}
+🐻 hibernate	${hib:-systemctl hibernate -i}
 🔃 reboot	${reb:-sudo -A reboot}
 🖥 shutdown	${shut:-sudo -A shutdown -h now}
 📺 display off 	 xset dpms force off"
@@ -21,3 +21,6 @@ cmds="\
 choice="$(echo "$cmds" | cut -d'	' -f 1 | dmenu)" || exit 1
 
 `echo "$cmds" | grep "^$choice	" | cut -d '	' -f2-`
+case "$choice" in
+	*"sleep"*|*"hibernate"*) slock;;
+esac

--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -5,7 +5,7 @@
 # For non-systemd init systems.
 case "$(readlink -f /sbin/init)" in
 	*runit*) slp="sudo -A zzz -z"; hib="sudo -A zzz -Z" ;;
-	*openrc*) reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p 0" ;;
+	*openrc*) slp="echo mem | sudo -A tee /sys/power/state"; hib="echo disk | sudo -A tee /sys/power/state"; reb="sudo -A openrc-shutdown -r"; shut="sudo -A openrc-shutdown -p 0" ;;
 esac
 
 cmds="\


### PR DESCRIPTION
I've made some small improvements in the `sysact` script, but not in a stupid way this time.

Firstly, I added the option to put the system to sleep instead of hibernate (good for people without or with low amounts of swap). Also, I added the ability for OpenRC users to sleep/hibernate the system. Finally, I fixed the annoying issue with `slock` running `sudo` as the wrong user, which should fix all the issues I was aiming to fix last time.

After [investigating](https://i.imgur.com/6ZBYnxU.png), I found that the root cause of the issues was that slock (for some reason) decides to run the commands your provide it as the "nobody" user - who isn't in the sudoers file and doesn't have SUDO_ASKPASS set. So, it messes stuff up. I fixed it by not using this feature of slock and just running the commands ourselves, with slock later.