### PR TITLE
Suppress sb-music errors

### DIFF
--- a/.local/bin/statusbar/sb-music
+++ b/.local/bin/statusbar/sb-music
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d" | paste -sd ' ' -;}
+filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d;/^ERROR/Q" | paste -sd ' ' -;}
 
 pidof -x sb-mpdup >/dev/null 2>&1 || sb-mpdup >/dev/null 2>&1 &
 


### PR DESCRIPTION
On many of the machines that I install the rice, users have external storages for storing their music. When not attached, it usually leaves an ugly error message in the statusbar (`ERROR: Failed to decode /home/user/Music/path/...`).

It seems this extra sed command prevents it.