### PR TITLE
fix sb-price: touch missing files

### DIFF
--- a/.local/bin/statusbar/sb-price
+++ b/.local/bin/statusbar/sb-price
@@ -16,6 +16,8 @@ updateprice() { ping -q -c 1 example.org >/dev/null 2>&1 &&
 	curl -s "rate.sx/$1$interval" > "$chartfile" ;}
 
 [ -d "$dir" ] || mkdir -p "$dir"
+[ -f "$pricefile" ] || touch "$pricefile"
+[ -f "$chartfile" ] || touch "$chartfile"
 
 [ "$(stat -c %x "$pricefile" 2>/dev/null | cut -d' ' -f1)" != "$(date '+%Y-%m-%d')" ] &&
 	updateprice "$1"


### PR DESCRIPTION
fixed a case where on first run, the file will not exist and the `cat` inside `printf` in line 40 will show give an error instead of doing something useful

not sure if one wants to always create the missing file, thus adjust if needed.