### PR TITLE
fix update colorsheme on boot

### DIFF
--- a/.local/bin/setbg
+++ b/.local/bin/setbg
@@ -18,7 +18,7 @@ esac
 
 # If pywal is installed, use it.
 command -v wal >/dev/null 2>&1 &&
-	wal -i "$trueloc" -o "${XDG_CONFIG_HOME:-$HOME/.config}/wal/postrun" >/dev/null 2>&1 &&
+	wal -i "$(readlink -f $bgloc)" -o "${XDG_CONFIG_HOME:-$HOME/.config}/wal/postrun" >/dev/null 2>&1 &&
 	pidof dwm >/dev/null && xdotool key super+F12
 
 xwallpaper --zoom "$bgloc"


### PR DESCRIPTION
run wal even if there is no file as argument by looking at the true location of the bg link