### PR TITLE
Here program name should be given not package name

### DIFF
--- a/.local/bin/torwrap
+++ b/.local/bin/torwrap
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ifinstalled tremc-git transmission-cli || exit
+ifinstalled tremc transmission-cli || exit
 
 ! pidof transmission-daemon >/dev/null && transmission-daemon && notify-send "Starting torrent daemon..."
 


### PR DESCRIPTION
    This can be known from "ifinstalled" code
    
    Otherwise, it results in error and reports that "tremc-git" must be installed even though it's installed already.