### PR TITLE
use just awk without grep

### DIFF
--- a/.local/bin/dmenurecord
+++ b/.local/bin/dmenurecord
@@ -31,7 +31,7 @@ screencast() { \
 	ffmpeg -y \
 	-f x11grab \
 	-framerate 60 \
-	-s "$(xdpyinfo | grep dimensions | awk '{print $2;}')" \
+	-s "$(xdpyinfo | awk '/dimensions/ {print $2;}')" \
 	-i "$DISPLAY" \
 	-f alsa -i default \
 	-r 30 \
@@ -43,7 +43,7 @@ screencast() { \
 
 video() { ffmpeg \
 	-f x11grab \
-	-s "$(xdpyinfo | grep dimensions | awk '{print $2;}')" \
+	-s "$(xdpyinfo | awk '/dimensions/ {print $2;}')" \
 	-i "$DISPLAY" \
  	-c:v libx264 -qp 0 -r 30 \
 	"$HOME/video-$(date '+%y%m%d-%H%M-%S').mkv" &


### PR DESCRIPTION
You can just use `awk '/thing/ {print ...}'` instead of `grep thing | awk '{print ...}'`, you probably already know this but haven't noticed this yet in this script.
