### PR TITLE
vim-airline repo changed its ownership from bling to vim-airline

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -14,7 +14,7 @@ Plug 'junegunn/goyo.vim'
 Plug 'jreybert/vimagit'
 Plug 'lukesmithxyz/vimling'
 Plug 'vimwiki/vimwiki'
-Plug 'bling/vim-airline'
+Plug 'vim-airline/vim-airline'
 Plug 'tpope/vim-commentary'
 Plug 'ap/vim-css-color'
 call plug#end()


### PR DESCRIPTION
github automatically redirects to vim-airline, so this is not a
problem when installing, but updating just for the sake of
explicitness and having the correct username/repo

to verify here's the vim-airline link https://github.com/vim-airline/vim-airline