### PR TITLE
add `/efi` to exceptions in dmenuunmount script

### DIFF
--- a/.local/bin/dmenuumount
+++ b/.local/bin/dmenuumount
@@ -26,7 +26,7 @@ asktype() { \
 	esac
 	}
 
-drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$4!~/\/boot|\/home$|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
+drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$4!~/\/boot|\/efi|\/home$|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
 
 if ! grep simple-mtpfs /etc/mtab; then
 	[ -z "$drives" ] && echo "No drives to unmount." &&  exit


### PR DESCRIPTION
people who have installed their system in EFI may accidentally unmount their boot partition, thus creating problems when upgrading their system's kernel.