### PR TITLE
update `ext` script

### DIFF
--- a/.local/bin/ext
+++ b/.local/bin/ext
@@ -24,15 +24,15 @@ fi
 
 if [ -f "$archive" ] ; then
 	case "$archive" in
-		*.tar.bz2|*.tbz2) tar xvjf "$archive" ;;
-		*.tar.xz) tar -xf "$archive" ;;
-		*.tar.gz|*.tgz) tar xvzf "$archive" ;;
-		*.tar.zst) tar -I zstd -xf "$archive" ;;
+		*.tar.bz2|*.tbz2) bsdtar -xf "$archive" ;;
+		*.tar.xz) bsdtar -xf "$archive" ;;
+		*.tar.gz|*.tgz) bsdtar -xf "$archive" ;;
+		*.tar.zst) bsdtar -xf "$archive" ;;
+		*.tar) bsdtar -xf "$archive" ;;
 		*.lzma) unlzma "$archive" ;;
 		*.bz2) bunzip2 "$archive" ;;
 		*.rar) unrar x -ad "$archive" ;;
 		*.gz) gunzip "$archive" ;;
-		*.tar) tar xvf "$archive" ;;
 		*.zip) unzip "$archive" ;;
 		*.Z) uncompress "$archive" ;;
 		*.7z) 7z x "$archive" ;;


### PR DESCRIPTION
Arch & Artix already have the `libarchive` pkg, which contains `bsdtar` (can't even uninstall it).
So lets just use it, since its already there, superior, faster, it also has easier syntax, and it auto-detects the compression.
<details>
<summary> btw the .tar.zst was wrong anyhow, so if u wont merge this, dont forget to fix that. from the manual: </summary>

```
-I, --use-compress-program=COMMAND
        Filter data through COMMAND.  It must accept the -d option, for decompression.  The argument can contain command line options.
...
...
--zstd Filter the archive through zstd(1).
```
dont use `-I zstd`, just use `--zstd`. __i think__.
</details>
