### PR TITLE
Changed paru to yay due to new LARBS changes

### DIFF
--- a/.local/bin/statusbar/sb-popupgrade
+++ b/.local/bin/statusbar/sb-popupgrade
@@ -2,7 +2,7 @@
 
 printf "Beginning upgrade.\\n"
 
-paru -Syu
+yay -Syu
 pkill -RTMIN+8 "${STATUSBAR:-dwmblocks}"
 
 printf "\\nUpgrade complete.\\nPress <Enter> to exit window.\\n\\n"


### PR DESCRIPTION
In [https://github.com/LukeSmithxyz/LARBS/commit/b4167af0e79dab3a618059438a371fc733562978](url) the default AUR helper was changed from paru to yay. The sb-popupgrade script should also have this change.