### PR TITLE
Add partition labelling to dmenumount

### DIFF
--- a/.local/bin/dmenumount
+++ b/.local/bin/dmenumount
@@ -50,7 +50,7 @@ asktype() { \
 	}
 
 anddrives=$(simple-mtpfs -l 2>/dev/null)
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint" | grep 'part\|rom' | awk '$4==""{printf "%s (%s)\n",$1,$3}')"
+usbdrives="$(lsblk -rpo "name,type,size,label,mountpoint" | grep 'part\|rom' | sed 's/ /:/g' | awk -F':' '$5==""{printf "%s (%s) %s\n",$1,$3,$4}')"
 
 if [ -z "$usbdrives" ]; then
 	[ -z "$anddrives" ] && echo "No USB drive or Android device detected" && exit


### PR DESCRIPTION
If a partition doesn't have a label, it results in a double space that awk ignores. Which is why the changes include a pipe into sed.