### PR TITLE
Add partition label to dmenuumount script

### DIFF
--- a/.local/bin/dmenuumount
+++ b/.local/bin/dmenuumount
@@ -26,7 +26,7 @@ asktype() { \
 	esac
 	}
 
-drives=$(lsblk -nrpo "name,type,size,mountpoint" | awk '$4!~/\/boot|\/efi|\/home$|SWAP/&&length($4)>1{printf "%s (%s)\n",$4,$3}')
+drives=$(lsblk -nrpo "name,type,size,mountpoint,label" | sed 's/ /:/g' | awk -F':' '$4!~/\/boot|\/efi|\/home$|SWAP/&&length($4)>1{printf "%s (%s) %s\n",$4,$3,$5}')
 
 if ! grep simple-mtpfs /etc/mtab; then
 	[ -z "$drives" ] && echo "No drives to unmount." &&  exit


### PR DESCRIPTION
If a partition doesn't have a label, it results in a double space that awk ignores. Which is why the changes include a pipe into sed.