### PR TITLE
Small newsup fix

### DIFF
--- a/.local/bin/cron/newsup
+++ b/.local/bin/cron/newsup
@@ -5,7 +5,7 @@
 
 /usr/bin/notify-send "📰 Updating RSS feeds..."
 
-pgrep -f newsboat$ && /usr/bin/xdotool key --window "$(/usr/bin/xdotool search --name newsboat)" R && exit
+pgrep -f newsboat$ && /usr/bin/xdotool key --window "$(/usr/bin/xdotool search --name "^newsboat$")" R && exit
 
 echo 🔃 > /tmp/newsupdate
 pkill -RTMIN+6 "${STATUSBAR:-dwmblocks}"


### PR DESCRIPTION
Don't update windows just because they have "newsboat" in them. I noticed this after I left the newsboat docs open in the browser the other day and it kept being reloaded.