### PR TITLE
Adds xinitrc symlink

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,0 +1,1 @@
+.config/x11/xinitrc


### PR DESCRIPTION
I installed larbs.sh a couple times yesterday on both Arch and Artix. I noticed the symlink from ~ to ~/.config/x11/xinitrc was missing. 
It's a small thing, but without it X can't start.