### PR TITLE
Fixed peertubetorrent

### DIFF
--- a/.local/bin/peertubetorrent
+++ b/.local/bin/peertubetorrent
@@ -3,7 +3,7 @@
 # first argument is the video link, second is the quality (480 or 1080)
 # 13/07/20 - Arthur Bais
 
-instance=$(echo "$1" | sed "s/\/w.*//")
-vidid=$(echo "$1" | sed "s/.*\///")
-link=$(curl "$instance/api/v1/videos/$vidid" 2>/dev/null | grep -o "$instance/download/torrents/........-....-....-....-............-$2.torrent")
+instance=$(echo "$1" | sed "s/\/w.\+//")
+vidid=$(echo "$1" | sed "s/.\+\///")
+link=$(curl -s "$instance/api/v1/videos/$vidid" | grep -o "$instance/download/torrents/\([^-]\+-\)\{5\}$2.torrent")
 transadd "$link"

--- a/.local/bin/peertubetorrent
+++ b/.local/bin/peertubetorrent
@@ -3,7 +3,7 @@
 # first argument is the video link, second is the quality (360, 480 or 1080)
 # 13/07/20 - Arthur Bais
 
-instance=$(echo $1 | sed "s/\/w.\+//")
-vidid=$(echo $1 | sed "s/.\+\///")
+instance=$(echo "$1" | sed "s/\/w.\+//")
+vidid=$(echo "$1" | sed "s/.\+\///")
 link=$(curl -s "$instance/api/v1/videos/$vidid" | grep -o "$instance/download/torrents/.\{37\}$2.torrent")
-transadd $link
+transadd "$link"

--- a/.local/bin/peertubetorrent
+++ b/.local/bin/peertubetorrent
@@ -3,5 +3,7 @@
 # first argument is the video link, second is the quality (480 or 1080)
 # 13/07/20 - Arthur Bais
 
-link="$(echo "$1" | sed "s/w/download\/torrents/")""-$2.torrent"
+instance=$(echo "$1" | sed "s/\/w.*//")
+vidid=$(echo "$1" | sed "s/.*\///")
+link=$(curl "$instance/api/v1/videos/$vidid" 2>/dev/null | grep -o "$instance/download/torrents/........-....-....-....-............-$2.torrent")
 transadd "$link"

--- a/.local/bin/peertubetorrent
+++ b/.local/bin/peertubetorrent
@@ -1,6 +1,6 @@
 #!/bin/sh
 # torrent peertube videos, requires the transadd script
-# first argument is the video link, second is the quality (480 or 1080)
+# first argument is the video link, second is the quality (360, 480 or 1080)
 # 13/07/20 - Arthur Bais
 
 instance=$(echo "$1" | sed "s/\/w.\+//")

--- a/.local/bin/peertubetorrent
+++ b/.local/bin/peertubetorrent
@@ -3,7 +3,7 @@
 # first argument is the video link, second is the quality (360, 480 or 1080)
 # 13/07/20 - Arthur Bais
 
-instance=$(echo "$1" | sed "s/\/w.\+//")
-vidid=$(echo "$1" | sed "s/.\+\///")
-link=$(curl -s "$instance/api/v1/videos/$vidid" | grep -o "$instance/download/torrents/\([^-]\+-\)\{5\}$2.torrent")
-transadd "$link"
+instance=$(echo $1 | sed "s/\/w.\+//")
+vidid=$(echo $1 | sed "s/.\+\///")
+link=$(curl -s "$instance/api/v1/videos/$vidid" | grep -o "$instance/download/torrents/.\{37\}$2.torrent")
+transadd $link


### PR DESCRIPTION
Because of https://github.com/Chocobozzz/PeerTube/pull/3746, the torrent URL is now different from the normal video url. This means the peertube API is needed to get the new torrent link.