### PR TITLE
-lm flag to cc to compile math.h headers

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -29,7 +29,7 @@ textype() { \
 case "$ext" in
 	# Try to keep these cases in alphabetical order.
 	[0-9]) preconv "$file" | refer -PS -e | groff -mandoc -T pdf > "$base".pdf ;;
-	c) cc "$file" -o "$base" && "$base" ;;
+	c) cc "$file" -o "$base" -lm && "$base" ;;
 	cpp) g++ "$file" -o "$base" && "$base" ;;
 	cs) mcs "$file" && mono "$base".exe ;;
 	go) go run "$file" ;;


### PR DESCRIPTION
noticed a problem with the compiler program which didn't compile C programs with math.h headers, seemed like a problem only for math.h, this fixes the issue