### PR TITLE
Make the password prompt invisible

### DIFF
--- a/.local/bin/dmenupass
+++ b/.local/bin/dmenupass
@@ -3,4 +3,4 @@
 # This script is the SUDO_ASKPASS variable, meaning that it will be used as a
 # password prompt if needed.
 
-dmenu -fn Monospace-18 -P -p "$1" <&- && echo
+dmenu -nf "#222222" -fn Monospace-18 -p "$1" <&-


### PR DESCRIPTION
I made the password prompt invisible by defining a foreground color, and removed the non working -P option and I also removed the echo because it's not needed, Here it is in action: https://imgur.com/a/A1eax2b