### PR TITLE
follow symlinks when detecting filetype in lf

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -14,7 +14,7 @@ $lf -remote "send $id set previewer ${XDG_CONFIG_HOME:-$HOME/.config}/lf/scope"
 
 # cmds/functions
 cmd open ${{
-    case $(file --mime-type $f -b) in
+    case $(file --mime-type "$(readlink -f $f)" -b) in
 	image/vnd.djvu|application/pdf|application/octet-stream|application/postscript) setsid -f zathura $fx >/dev/null 2>&1 ;;
         text/*) $EDITOR $fx;;
 	image/x-xcf) setsid -f gimp $f >/dev/null 2>&1 ;;


### PR DESCRIPTION
fix bug in lf where symlinked files don't open in the expected program