### PR TITLE
Update sysact

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -5,14 +5,14 @@ case "$(readlink -f /sbin/init)" in
 	*) ctl='loginctl' ;;
 esac
 
-case "$(printf "🔒 lock\n🚪 leave dwm\n♻️ renew dwm\n🐻 hibernate\n💤 sleep\n🔃 reboot\n🖥️shutdown\n📺 display off" | dmenu -i -p 'Action: ')" in
+case "$(printf "🔒 lock\n🚪 leave dwm\n♻ renew dwm\n🐻 hibernate\n💤 sleep\n🔃 reboot\n🖥 shutdown\n📺 display off" | dmenu -i -p 'Action: ')" in
 	'🔒 lock') slock ;;
 	'🚪 leave dwm') kill -TERM "$(pgrep -u "$USER" "\bdwm$")" ;;
-	'♻️ renew dwm') kill -HUP "$(pgrep -u "$USER" "\bdwm$")" ;;
+	'♻ renew dwm') kill -HUP "$(pgrep -u "$USER" "\bdwm$")" ;;
 	'🐻 hibernate') slock $ctl hibernate ;;
 	'💤 sleep') slock $ctl suspend ;;
 	'🔃 reboot') $ctl reboot ;;
-	'🖥️shutdown') $ctl poweroff ;;
+	'🖥 shutdown') $ctl poweroff ;;
 	'📺 display off') xset dpms force off ;;
 	*) exit 1 ;;
 esac


### PR DESCRIPTION
this change removes the incorrect white space char next to `shutdown` and `renew` and replaces it with a regular white space char.

The change is not fully reflected in the diff that github shows. I think github identifies both white space chars as the same char.

You're probably thinking "WTF is this guy talking about". If so, please replicate the issue by changing the default font / dmenu's font to Liberation Mono and hit Mod+BackSpace. You should see box chars next to  `shutdown` and `renew`.