### PR TITLE
README inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Voidrice (Luke Smith <https://lukesmith.xyz>'s dotfiles)
+# The Voidrice ([Luke Smith](https://lukesmith.xyz)'s dotfiles)
 
 These are the dotfiles deployed by [LARBS](https://larbs.xyz) and as seen on
 [my YouTube channel](https://youtube.com/c/lukesmithxyz).


### PR DESCRIPTION
I don't know if there is a reason for this but every other link is paired with a word.