### PR TITLE
Fix case-matching

### DIFF
--- a/.local/bin/dmenuhandler
+++ b/.local/bin/dmenuhandler
@@ -5,7 +5,7 @@
 feed="${1:-$(printf "%s" | dmenu -p 'Paste URL or file path')}"
 
 case "$(printf "Copy URL\\nsxiv\\nsetbg\\nPDF\\nbrowser\\nlynx\\nvim\\nmpv\\nmpv loop\\nmpv float\\nqueue download\\nqueue yt-dl\\nqueue yt-dl audio" | dmenu -i -p "Open it with?")" in
-	"copy url") echo "$feed" | xclip -selection clipboard ;;
+	"Copy URL") echo "$feed" | xclip -selection clipboard ;;
 	mpv) setsid -f mpv -quiet "$feed" >/dev/null 2>&1 ;;
 	"mpv loop") setsid -f mpv -quiet --loop "$feed" >/dev/null 2>&1 ;;
 	"mpv float") setsid -f "$TERMINAL" -e mpv --geometry=+0-0 --autofit=30%  --title="mpvfloat" "$feed" >/dev/null 2>&1 ;;


### PR DESCRIPTION
Case sensitivity prevents dmenuhandler from copying the URL to the clipboard.