### PR TITLE
Move to data folder and need absolute path here

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -97,7 +97,7 @@ set noshowcmd
 " Ensure files are read as what I want:
 	let g:vimwiki_ext2syntax = {'.Rmd': 'markdown', '.rmd': 'markdown','.md': 'markdown', '.markdown': 'markdown', '.mdown': 'markdown'}
 	map <leader>v :VimwikiIndex<CR>
-	let g:vimwiki_list = [{'path': '.config/nvim/vimwiki', 'syntax': 'markdown', 'ext': '.md'}]
+	let g:vimwiki_list = [{'path': '~/.local/share/nvim/vimwiki', 'syntax': 'markdown', 'ext': '.md'}]
 	autocmd BufRead,BufNewFile /tmp/calcurse*,~/.calcurse/notes/* set filetype=markdown
 	autocmd BufRead,BufNewFile *.ms,*.me,*.mom,*.man set filetype=groff
 	autocmd BufRead,BufNewFile *.tex set filetype=tex


### PR DESCRIPTION
    Vimwiki is not config but it's data so ".local/share/nvim" is
    more proper location for it.

    Here relative path was given so it tries to create new vimwiki
    folder when launched from other than home dir or changing current
    dir using `:cd <path>` inside vim when launching vimwiki.