### PR TITLE
Keep trailing whitespaces for *.md files

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -111,10 +111,12 @@ set noshowcmd
 	autocmd BufRead,BufNewFile /tmp/neomutt* map ZZ :Goyo\|x!<CR>
 	autocmd BufRead,BufNewFile /tmp/neomutt* map ZQ :Goyo\|q!<CR>
 
-" Automatically deletes all trailing whitespace and newlines at end of file on save. & reset cursor position
  	autocmd BufWritePre * let currPos = getpos(".")
-	autocmd BufWritePre * %s/\s\+$//e
-	autocmd BufWritePre * %s/\n\+\%$//e
+" Remove trailing whitespaces except in '.md' files
+    autocmd BufWritePre *[^m][^d] %s/\s\+$//e
+" Remove trailing newlines at the end of file
+    autocmd BufWritePre * %s/\n\+\%$//e
+" Replace trailing newlines with one newline in '.c' or '.h' files
 	autocmd BufWritePre *.[ch] %s/\%$/\r/e
   	autocmd BufWritePre * cal cursor(currPos[1], currPos[2])
 


### PR DESCRIPTION
    They are syntax for the md files so they should stay.

    Also added some documentation.