### PR TITLE
Change Linux Libertine to Libertinus

### DIFF
--- a/.config/fontconfig/fonts.conf
+++ b/.config/fontconfig/fonts.conf
@@ -4,7 +4,7 @@
 	<alias>
 		<family>serif</family>
 		<prefer>
-			<family>Linux Libertine</family>
+			<family>Libertinus</family>
 			<family>Joy Pixels</family>
 			<family>Noto Color Emoji</family>
 		</prefer>


### PR DESCRIPTION
Linux Libertine is no longer developed and Libertinus is the successor. Libertine will no longer be in the repos after 2022.