### PR TITLE
Uses pywal

### DIFF
--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -4,7 +4,7 @@
 # If you use startx/xinit like a Chad, this file will also be sourced.
 
 xrandr --dpi 96		# Set DPI. User may want to use a larger number for larger screens.
-setbg &			# set the background with the `setbg` script
+setbg ${XDG_DATA_HOME:-$HOME/.local/share/}/bg &			# set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources & xrdbpid=$!	# Uncomment to use Xresources colors/settings on startup
 remaps &		# run the remaps script, switching caps/esc and more; check it for more info
 


### PR DESCRIPTION
proposed changing `setbg &` in `xprofile` to `setbg ~/.local/share/bg &` so that it will also effect pywal. I was previously going to do this;

> `setbg` uses user input to set the background as well as pywal when installed. `setbg` by itself (no user input) changes the background to `~/.local/share/bg` but doesn't effect pywal. I think that exporting the background path in an environment variable and using that variable as input to `setbg &` in `xprofile` to effect pywal. you can use `sed` and parse `>>` with minor editing to the `setbg` script to accomplish this.

Even though its a lot more dynamic its more disgusting, though it would be a better option in some cases.