### PR TITLE
file.desktop: Use `lfub` instead of plain `lf`

### DIFF
--- a/.local/share/applications/file.desktop
+++ b/.local/share/applications/file.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Type=Application
 Name=File Manager
-Exec=/usr/local/bin/st -e lf %u
+Exec=/usr/local/bin/st -e lfub %u


### PR DESCRIPTION
'file.desktop' uses `lf` instead of the wrapper script `lfub`