### PR TITLE
 remove xmodmap from remaps script

### DIFF
--- a/.local/bin/remaps
+++ b/.local/bin/remaps
@@ -1,13 +1,11 @@
 #!/bin/sh
 
 # This script is called on startup to remap keys.
-# Increase key speed via a rate change
+# Decrease key repeat delay to 300ms and increase key repeat rate to 50 per second.
 xset r rate 300 50
-# Map the caps lock key to super...
-setxkbmap -option caps:super
-# But when it is pressed only once, treat it as escape.
+# Map the caps lock key to super, and map the menu key to right super.
+setxkbmap -option caps:super,altwin:menu_win
+# When caps lock is pressed only once, treat it as escape.
 killall xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
-# Map the menu button to right super as well.
-xmodmap -e 'keycode 135 = Super_R'
-# Turn off the caps lock if on since there is no longer a key for it.
+# Turn off caps lock if on since there is no longer a key for it.
 xset -q | grep "Caps Lock:\s*on" && xdotool key Caps_Lock


### PR DESCRIPTION
Uses the `altwin:menu` option from setxkbmap to map the menu key to right super instead of xmodmap, which is deprecated. setxkbmap's options can be viewed with `man xkeyboard-config`. Also tried to make the comment for the xset rate change more helpful.