### PR TITLE
use setxkbmap to set menu button to super key

### DIFF
--- a/.local/bin/remaps
+++ b/.local/bin/remaps
@@ -4,10 +4,8 @@
 # Increase key speed via a rate change
 xset r rate 300 50
 # Map the caps lock key to super...
-setxkbmap -option caps:super
+setxkbmap -option "caps:super,altwin:menu_win"
 # But when it is pressed only once, treat it as escape.
 killall xcape 2>/dev/null ; xcape -e 'Super_L=Escape'
-# Map the menu button to right super as well.
-xmodmap -e 'keycode 135 = Super_R'
 # Turn off the caps lock if on since there is no longer a key for it.
 xset -q | grep "Caps Lock:\s*on" && xdotool key Caps_Lock


### PR DESCRIPTION
There is an option in [`setxkbmap` man page](https://man.archlinux.org/man/xkeyboard-config.7.en) to set menu button to super (win) key.