### PR TITLE
Screenshot utility improvements (maimpick)

### DIFF
--- a/.local/bin/maimpick
+++ b/.local/bin/maimpick
@@ -4,11 +4,15 @@
 # choose the kind of screenshot to take, including copying the image or even
 # highlighting an area to copy. scrotcucks on suicidewatch right now.
 
+# variables
+output="$(date '+%y%m%d-%H%M-%S').png"
+xclip_cmd="xclip -sel clip -t image/png"
+
 case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
-    "a selected area") maim -s pic-selected-"$(date '+%y%m%d-%H%M-%S').png" ;;
-    "current window") maim -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
-    "full screen") maim -q -d 0.2 pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;
-    "a selected area (copy)") maim -s | xclip -selection clipboard -t image/png ;;
-    "current window (copy)") maim -q -d 0.2 -i "$(xdotool getactivewindow)" | xclip -selection clipboard -t image/png ;;
-    "full screen (copy)") maim -q -d 0.2 | xclip -selection clipboard -t image/png ;;
+    "a selected area") maim -s pic-selected-"${output}" ;;
+    "current window") maim -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"${output}" ;;
+    "full screen") maim -q -d 0.2 pic-full-"${output}" ;;
+    "a selected area (copy)") maim -s | ${xclip_cmd} ;;
+    "current window (copy)") maim -q -d 0.2 -i "$(xdotool getactivewindow)" | ${xclip_cmd} ;;
+    "full screen (copy)") maim -q -d 0.2 | ${xclip_cmd} ;;
 esac

--- a/.local/bin/maimpick
+++ b/.local/bin/maimpick
@@ -5,10 +5,10 @@
 # highlighting an area to copy. scrotcucks on suicidewatch right now.
 
 case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
-	"a selected area") maim -s pic-selected-"$(date '+%y%m%d-%H%M-%S').png" ;;
-	"current window") maim -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
-	"full screen") maim pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;
-	"a selected area (copy)") maim -s | xclip -selection clipboard -t image/png ;;
-	"current window (copy)") maim -i "$(xdotool getactivewindow)" | xclip -selection clipboard -t image/png ;;
-	"full screen (copy)") maim | xclip -selection clipboard -t image/png ;;
+    "a selected area") maim -s pic-selected-"$(date '+%y%m%d-%H%M-%S').png" ;;
+    "current window") maim -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"$(date '+%y%m%d-%H%M-%S').png" ;;
+    "full screen") maim -q -d 0.2 pic-full-"$(date '+%y%m%d-%H%M-%S').png" ;;
+    "a selected area (copy)") maim -s | xclip -selection clipboard -t image/png ;;
+    "current window (copy)") maim -q -d 0.2 -i "$(xdotool getactivewindow)" | xclip -selection clipboard -t image/png ;;
+    "full screen (copy)") maim -q -d 0.2 | xclip -selection clipboard -t image/png ;;
 esac


### PR DESCRIPTION
## [09af0a7](https://github.com/LukeSmithxyz/voidrice/commit/09af0a77b37e56272dc2937d589eda33d30e2da0) - maimpick delay for proper screenshots

**Before**:
![maim-before](https://user-images.githubusercontent.com/51257127/165828254-2fe9e9bb-7996-49cc-a98a-98638690e641.png)

**After**:
![maim-after](https://user-images.githubusercontent.com/51257127/165828300-94f4328a-e66b-45b9-be8c-a2eaec4567dc.png)

Please read the commit for extra details.

---

## [dcbb7dc](https://github.com/LukeSmithxyz/voidrice/commit/dcbb7dca2a3b27183a1523bbbbacb353b34dc0d7) - refactor to extract commonly used commands

This just makes the script easier to read and avoid repetition.

---

Excuse the tab-space formatting, it got in the way unfortunately; I can re-commit if it's a bother.