### PR TITLE
shortcuts: make `ls` command configurable

### DIFF
--- a/.local/bin/shortcuts
+++ b/.local/bin/shortcuts
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ -z "$SHORTCUTS_LS_CMD" ] && SHORTCUTS_LS_CMD="ls -a"
+
 bmdirs="${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs"
 bmfiles="${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-files"
 
@@ -22,9 +24,9 @@ printf "\" vim: filetype=vim\\n" > "$vifm_shortcuts"
 # Format the `directories` file in the correct syntax and sent it to all three configs.
 eval "echo \"$(cat "$bmdirs")\"" | \
 awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
-	printf(\"%s=\42cd %s && ls -a\42 \\\\\n\",\$1,\$2)   >> \"$shell_shortcuts\" ;
+	printf(\"%s=\42cd %s && $SHORTCUTS_LS_CMD\42 \\\\\n\",\$1,\$2)   >> \"$shell_shortcuts\" ;
 	printf(\"hash -d %s=%s \n\",\$1,\$2)                 >> \"$zsh_named_dirs\"  ;
-	printf(\"abbr %s \42cd %s; and ls -a\42\n\",\$1,\$2) >> \"$fish_shortcuts\"  ;
+	printf(\"abbr %s \42cd %s; and $SHORTCUTS_LS_CMD\42\n\",\$1,\$2) >> \"$fish_shortcuts\"  ;
 	printf(\"map g%s :cd %s<CR>\nmap t%s <tab>:cd %s<CR><tab>\nmap M%s <tab>:cd %s<CR><tab>:mo<CR>\nmap Y%s <tab>:cd %s<CR><tab>:co<CR> \n\",\$1,\$2, \$1, \$2, \$1, \$2, \$1, \$2)       >> \"$vifm_shortcuts\" ;
 	printf(\"config.bind(';%s', \42set downloads.location.directory %s ;; hint links download\42) \n\",\$1,\$2) >> \"$qute_shortcuts\" ;
 	printf(\"map g%s cd %s\nmap t%s tab_new %s\nmap m%s shell mv -v %%s %s\nmap Y%s shell cp -rv %%s %s \n\",\$1,\$2,\$1,\$2, \$1, \$2, \$1, \$2) >> \"$ranger_shortcuts\" ;


### PR DESCRIPTION
when merging from upstream (you) it's always a hassle
to resolve the changes in this file,
but it shouldn't be, because the only modification i make
is to change the way the `ls` command behaves.

thus by extracting the SHORTCUTS_LS_CMD command out,
even if it's edited in the file,
will no longer interfere w/ other logic of the program.

fwiw, i set mine to

```sh
ls -l --all --size --group-directories-first --human-readable --classify --color=auto
```
