### PR TITLE
Use tmpfs for speed and I/O  reduction

### DIFF
--- a/.local/bin/statusbar/sb-nettraf
+++ b/.local/bin/statusbar/sb-nettraf
@@ -17,7 +17,7 @@ update() {
         read -r i < "$arg"
         sum=$(( sum + i ))
     done
-    cache=${XDG_CACHE_HOME:-$HOME/.cache}/${1##*/}
+    cache=/tmp/${1##*/}
     [ -f "$cache" ] && read -r old < "$cache" || old=0
     printf %d\\n "$sum" > "$cache"
     printf %d\\n $(( sum - old ))


### PR DESCRIPTION
Right now the script writes to XDG cache directory - which is probably mounted at a physical drive.
I think it's unnecessary and might harm your disk in the long run.

It is also possible to change into /dev/shm/<filename> it case your /tmp directory is not mounted with tmpfs.

