### PR TITLE
Give linkhandler option to read from clipboard

### DIFF
--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -6,6 +6,11 @@
 # if a music file or pdf, it will download,
 # otherwise it opens link in browser.
 
+# If -c passed, read from clipboard
+while getopts 'c' o; do case "${o}" in
+	c) set "$(xclip -o)";;
+esac done
+
 # If no url given. Opens browser. For using script as $BROWSER.
 [ -z "$1" ] && { "$BROWSER"; exit; }
 


### PR DESCRIPTION
When passing the -c option, linkhandler reads from the clipboard. It's very useful if you have it bound as a macro, as you can copy a link in a browser, and can very easily open the copied url in a better application.