### PR TITLE
Fix fzf select in lf

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -94,7 +94,7 @@ cmd setbg "$1"
 cmd bulkrename $vidir
 
 # Bindings
-map <c-f> $lf -remote "send $id select '$(fzf)'"
+map <c-f> $lf -remote "send $id select \"$(fzf)\""
 map J $lf -remote "send $id cd $(sed -e 's/\s*#.*//' -e '/^$/d' -e 's/^\S*\s*//' ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf)"
 map gh
 map g top


### PR DESCRIPTION
Without double quotes, fzf-select fails when selecting a file whose path contains whitespace. 

If I recall correctly, it will raise the error "select: required an argument".