### PR TITLE
Lf better mimetypes

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -27,7 +27,7 @@ set previewer '~/.config/lf/scope'
 
 # cmds/functions
 cmd open ${{
-    case $(file --mime-type "$(readlink -f $f)" -b) in
+    case $(xdg-mime query filetype "$(readlink -f $f)" -b) in
 	application/vnd.openxmlformats-officedocument.spreadsheetml.sheet) localc $fx ;;
 	image/vnd.djvu|application/pdf|application/octet-stream|application/postscript) setsid -f zathura $fx >/dev/null 2>&1 ;;
         text/*|application/json|inode/x-empty) $EDITOR $fx;;

--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -21,7 +21,7 @@ ifub() {
 # an image appears in multiple places across the machine, it will not have to
 # be regenerated once seen.
 
-case "$(file --dereference --brief --mime-type -- "$1")" in
+case "$(xdg-mime query filetype "$1")" in
 	image/*) image "$1" "$2" "$3" "$4" "$5" "$1" ;;
 	text/html) lynx -width="$4" -display_charset=utf-8 -dump "$1" ;;
 	text/troff) man ./ "$1" | col -b ;;


### PR DESCRIPTION
I find "file --mime-type" entirely inaccurate at times, especially with more niche file types (such as .stl's). "xdg-mime query filetype" seems to be more accurate when giving certain file types. 