### PR TITLE
Change pipewire-media-session to wireplumber

### DIFF
--- a/.config/pipewire/pipewire.conf
+++ b/.config/pipewire/pipewire.conf
@@ -236,12 +236,12 @@ context.exec = [
     # but it is better to start it as a systemd service.
     # Run the session manager with -h for options.
     #
-    { path = "/usr/bin/pipewire-media-session" args = "" }
+    { path = "/usr/bin/wireplumber" args = "" }
     #
     # You can optionally start the pulseaudio-server here as well
     # but it is better to start it as a systemd service.
     # It can be interesting to start another daemon here that listens
     # on another address with the -a option (eg. -a tcp:4713).
     #
-    { path = "/usr/bin/pipewire" args = "-c pipewire-pulse.conf" }
+    { path = "/usr/bin/wireplumber" args = "-c pipewire-pulse.conf" }
 ]


### PR DESCRIPTION
pipewire-media-session is now in conflict with wireplumber, which is needed for pipewire-jack and pipewire-pulse. Amend pipewire config to use wireplumber instead.