### PR TITLE
fix wireplumber

### DIFF
--- a/.config/pipewire/pipewire.conf
+++ b/.config/pipewire/pipewire.conf
@@ -243,5 +243,5 @@ context.exec = [
     # It can be interesting to start another daemon here that listens
     # on another address with the -a option (eg. -a tcp:4713).
     #
-    { path = "/usr/bin/wireplumber" args = "-c pipewire-pulse.conf" }
+    { path = "/usr/bin/pipewire" args = "-c pipewire-pulse.conf" }
 ]


### PR DESCRIPTION
As we see in the docs here: https://pipewire.pages.freedesktop.org/wireplumber/running-wireplumber-daemon.html#pipewire-conf we need to start wireplumber in replace of the old media session, not "wireplumber as server". (This is my first hecking commit ever !!!!!!!!!)