### PR TITLE
Fix two bugs in booksplit script

### DIFF
--- a/.local/bin/booksplit
+++ b/.local/bin/booksplit
@@ -9,7 +9,7 @@ echo "Enter the artist/author:"; read -r author
 echo "Enter the publication year:"; read -r year
 
 inputaudio="$1"
-ext="${1#*.}"
+ext="${1##*.}"
 
 # Get a safe file name from the book.
 escbook="$(echo "$booktitle" | iconv -cf UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
@@ -25,12 +25,12 @@ cmd="ffmpeg -i \"$inputaudio\" -nostdin -y"
 
 while read -r x;
 do
-    end="$(echo "$x" | cut -d'	' -f1)"
+    end="$(echo "$x" | cut -d' ' -f1)"
     file="$escbook/$(printf "%.2d" "$track")-$esctitle.$ext"
     if [ -n "$start" ]; then
 	cmd="$cmd -metadata artist=\"$author\" -metadata title=\"$title\" -metadata album=\"$booktitle\" -metadata year=\"$year\" -metadata track=\"$track\" -metadata total=\"$total\" -ss \"$start\" -to \"$end\" -vn -c:a copy \"$file\" "
     fi
-    title="$(echo "$x" | cut -d'	' -f2-)"
+    title="$(echo "$x" | cut -d' ' -f2-)"
     esctitle="$(echo "$title" | iconv -cf UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
     track="$((track+1))"
     start="$end"


### PR DESCRIPTION
## Bug 1

Content of `timestamps.txt`:

```txt
00:00 Intro
00:15 WYS - Snowman
03:25 Fatb - Cotton Cloud
05:28 rook1e x tender spring - the places we used to walk
07:44 imagiro - wool gloves
10:28 Glimlip x Yasper - I'm sorry
12:43 mell-ø - Nova
14:24 goosetaf x the fields tape x francis - carried away
16:20 j'san x epektase - snow & sand
19:02 HM Surf - Single Phial
20:46 cocabona x Glimlip - Drops
22:43 Aso - espresso
25:10 Ambulo x mell-ø - Luminescence
26:50 DLJ x BIDØ - Explorers
28:48 Sarcastic Sounds - Wish You Were Mine
30:51 BluntOne - Reflections
32:48 Purrple Cat - Alone Time
36:08 Kupla - Owls of the Night
38:28 dryhope - Steps
40:54 ENRA - amber
42:20 Psalm Trees - fever
44:51 H.1 - Circle
46:41 Pandrezz - Cuddlin
49:32 Jordy Chandra - Late Night Call
51:44 less.people - Gyoza
53:42 G Mills - Keyframe
56:32 mvdb - breeze
58:06 Mondo Loops - Lunar Drive
```

Output after running `booksplit "1 A.M Study Session 📚 - [lofi hip hop_chill beats] [lTRiuFIWV54].mp3" timestampts.txt`:

![image](https://user-images.githubusercontent.com/71596800/180271266-047b838c-9060-4fc9-9335-e790bcb29df9.png)

Script does not work because of the wrong delimeter in the `cut` commands. 

## Bug 2

![image](https://user-images.githubusercontent.com/71596800/180271308-f7e0ece9-0a64-4e0d-b958-b845aced02e3.png)

If there is a `.` in the filename, all the filenames are messed up. Changing `ext="${1#*.}"` to `ext="${1##*.}"` fixes the problem.