### PR TITLE
decoupling wmpid

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -1,17 +1,10 @@
 #!/bin/sh
 
 # A dmenu wrapper script for system functions.
-export WM="dwm"
 case "$(readlink -f /sbin/init)" in
 	*systemd*) ctl='systemctl' ;;
 	*) ctl='loginctl' ;;
 esac
-
-wmpid(){ # This function is needed if there are multiple instances of the window manager.
-	tree="$(pstree -ps $$)"
-	tree="${tree#*$WM(}"
-	echo "${tree%%)*}"
-}
 
 case "$(printf "🔒 lock\n🚪 leave $WM\n♻️ renew $WM\n🐻 hibernate\n🔃 reboot\n🖥️shutdown\n💤 sleep\n📺 display off" | dmenu -i -p 'Action: ')" in
 	'🔒 lock') slock ;;

--- a/.local/bin/wmpid
+++ b/.local/bin/wmpid
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This function is needed if there are multiple instances of the window manager.
+
+export WM="dwm"
+wmpid(){
+	tree="$(pstree -ps $$)"
+	tree="${tree#*$WM(}"
+	echo "${tree%%)*}"
+}
+
+eval wmpid


### PR DESCRIPTION
Decouple wmpid from sysact into a separate script. This makes it easier to script the equivalent of "renew dwm" and "leave dwm".