### PR TITLE
Parse tex root for more complex latex projects

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -18,6 +18,8 @@ cd "$dir" || exit 1
 
 textype() { \
 	command="pdflatex"
+  	texroot=$(grep -Poi "^ *% *\! *tex root *= *\w+(?:\.\w*)?" "$file" | cut -d "=" -f 2 | tr -d "[:blank:]")
+  	[ -n "$texroot" ] && base=$texroot && echo "Compiling from TeX root: $texroot"
 	( head -n5 "$file" | grep -qi 'xelatex' ) && command="xelatex"
 	$command --output-directory="$dir" "$base" &&
 	grep -qi addbibresource "$file" &&


### PR DESCRIPTION
Allows parsing texroot comments so that you can compile a LaTeX document from outside of the document root, as long as it contains the usual magic comment format:
% !TEX root = doc.tex