### PR TITLE
Fix bug with spaces in directory names

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -85,10 +85,10 @@ set noshowcmd
 	nnoremap S :%s//g<Left><Left>
 
 " Compile document, be it groff/LaTeX/markdown/etc.
-	map <leader>c :w! \| !compiler %:p<CR>
+	map <leader>c :w! \| !compiler "%:p"<CR>
 
 " Open corresponding .pdf/.html or preview
-	map <leader>p :!opout %:p<CR>
+	map <leader>p :!opout "%:p"<CR>
 
 " Runs a script that cleans out tex build files whenever I close out of a .tex file.
 	autocmd VimLeave *.tex !texclear %


### PR DESCRIPTION
Sorry for making another pull request here, but I realized that the command would fail if the filepath contained spaces. Adding quotation marks fixes this issue