### PR TITLE
updated sb-volume for wireplumber implentation.

### DIFF
--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -4,27 +4,26 @@
 
 case $BLOCK_BUTTON in
 	1) setsid -f "$TERMINAL" -e pulsemixer ;;
-	2) pamixer -t ;;
-	4) pamixer --allow-boost -i 1 ;;
-	5) pamixer --allow-boost -d 1 ;;
+	2) wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle ;;
+	4) wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+ ;;
+	5) wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%- ;;
 	3) notify-send "📢 Volume module" "\- Shows volume 🔊, 🔇 if muted.
 - Middle click to mute.
 - Scroll to change." ;;
 	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-[ $(pamixer --get-mute) = true ] && echo 🔇 && exit
+#echoing mute doenst work yet need help here
+[ $(wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep 'MUTED') = true ] && echo 🔇 && exit
 
-vol="$(pamixer --get-volume)"
+vol="$(wpctl get-volume @DEFAULT_AUDIO_SINK@ | cut -d ':' -f 2)"
 
 if [ "$vol" -gt "70" ]; then
 	icon="🔊"
-elif [ "$vol" -gt "30" ]; then
-	icon="🔉"
-elif [ "$vol" -gt "0" ]; then
+elif [ "$vol" -lt "30" ]; then
 	icon="🔈"
 else
-        echo 🔇 && exit
+	icon="🔉"
 fi
 
 echo "$icon$vol%"

--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -13,17 +13,9 @@ case $BLOCK_BUTTON in
 	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-#echoing mute doenst work yet need help here
-[ $(wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep 'MUTED') = true ] && echo 🔇 && exit
+wp="$(wpctl get-volume @DEFAULT_AUDIO_SINK@)"
+vol="$(echo $wp | awk '{print $2}')"
 
-vol="$(wpctl get-volume @DEFAULT_AUDIO_SINK@ | cut -d ':' -f 2)"
+ismuted="$(echo "$wp" | awk '{print $3}')"
 
-if [ "$vol" -gt "70" ]; then
-	icon="🔊"
-elif [ "$vol" -lt "30" ]; then
-	icon="🔈"
-else
-	icon="🔉"
-fi
-
-echo "$icon$vol%"
+[ -n "$ismuted" ] && echo "🔇"


### PR DESCRIPTION
Due to new update lots of arch and artix users has to switched from pulse audio to pipewire and wireplumber as a result old sb-volume script wont work properly.
I did some finding and got this amazing wpctl command which can be used to replace pamixer command.
Although i didnt completely understand why its showing volume level in decimals.
I tried my best. Its my first PR I think. Thank you.