### PR TITLE
Fix tag script mp3 issue

### DIFF
--- a/.local/bin/tag
+++ b/.local/bin/tag
@@ -54,10 +54,10 @@ Total=$total
 Date=$date
 Genre=$genre
 Comment=$comment" | opustags -i -S "$file" ;;
-	*.mp3) eyeD3 -Q --remove-all -a "$artist" -t "$title" -A "$album" -n "$track" \\
-		${total:+-N "$total"} \\
-		${date:+-Y "$date"} \\
-		${genre:+-G "$genre"} \\
+	*.mp3) eyeD3 -Q --remove-all -a "$artist" -t "$title" -A "$album" -n "$track" \
+		${total:+-N "$total"} \
+		${date:+-Y "$date"} \
+		${genre:+-G "$genre"} \
 		${comment:+-c "$comment"} "$file" ;;
 	*.flac) echo "TITLE=$title
 ARTIST=$artist

--- a/.local/bin/tag
+++ b/.local/bin/tag
@@ -54,7 +54,11 @@ Total=$total
 Date=$date
 Genre=$genre
 Comment=$comment" | opustags -i -S "$file" ;;
-	*.mp3) eyeD3 -Q --remove-all -a "$artist" -A "$album" -t "$title" -n "$track" -N "$total" -Y "$date" "$file" ;;
+	*.mp3) eyeD3 -Q --remove-all -a "$artist" -t "$title" -A "$album" -n "$track" \\
+		${total:+-N "$total"} \\
+		${date:+-Y "$date"} \\
+		${genre:+-G "$genre"} \\
+		${comment:+-c "$comment"} "$file" ;;
 	*.flac) echo "TITLE=$title
 ARTIST=$artist
 ALBUM=$album


### PR DESCRIPTION
When you don't manually specify $total and $date with an mp3 file the eyeD3 command tries tagging with an empty variable, which causes it to error. This fixes it by only passing the parameter to the command if the variable is set. 

This pull request also adds support for the $genre and $comment variable.