### PR TITLE
remove spacing from saved audio for tsp/newsboat

### DIFF
--- a/.config/newsboat/config
+++ b/.config/newsboat/config
@@ -32,7 +32,7 @@ color article white default bold
 browser linkhandler
 macro , open-in-browser
 macro t set browser "qndl" ; open-in-browser ; set browser linkhandler
-macro a set browser "tsp yt-dlp --embed-metadata -xic -f bestaudio/best" ; open-in-browser ; set browser linkhandler
+macro a set browser "tsp yt-dlp --embed-metadata -xic -f bestaudio/best --restrict-filenames" ; open-in-browser ; set browser linkhandler
 macro v set browser "setsid -f mpv" ; open-in-browser ; set browser linkhandler
 macro w set browser "lynx" ; open-in-browser ; set browser linkhandler
 macro d set browser "dmenuhandler" ; open-in-browser ; set browser linkhandler


### PR DESCRIPTION
The _--restrict-filenames_ parameter will automatically replace spaces with underlines.