### PR TITLE
underscore vs spaces, and naming convention

### DIFF
--- a/.local/bin/dmenuhandler
+++ b/.local/bin/dmenuhandler
@@ -10,7 +10,8 @@ case "$(printf "Copy URL\\nsxiv\\nsetbg\\nPDF\\nbrowser\\nlynx\\nvim\\nmpv\\nmpv
 	"mpv loop") setsid -f mpv -quiet --loop "$feed" >/dev/null 2>&1 ;;
 	"mpv float") setsid -f "$TERMINAL" -e mpv --geometry=+0-0 --autofit=30%  --title="mpvfloat" "$feed" >/dev/null 2>&1 ;;
 	"queue yt-dlp") qndl "$feed" >/dev/null 2>&1 ;;
-	"queue yt-dlp audio") qndl "$feed" 'yt-dlp --embed-metadata -icx -f bestaudio/best' >/dev/null 2>&1 ;;
+	"queue yt-dlp audio") qndl "$feed" 'yt-dlp -o '%(title)s.%(ext)s' -f bestaudio --embed-metadata --restrict-filenames'
+' >/dev/null 2>&1 ;;
 	"queue download") qndl "$feed" 'curl -LO' >/dev/null 2>&1 ;;
 	PDF) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s|.*/||;s/%20/ /g")" && zathura "/tmp/$(echo "$feed" | sed "s|.*/||;s/%20/ /g")"  >/dev/null 2>&1 ;;
 	sxiv) curl -sL "$feed" > "/tmp/$(echo "$feed" | sed "s|.*/||;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$feed" | sed "s|.*/||;s/%20/ /g")"  >/dev/null 2>&1 ;;


### PR DESCRIPTION
the title then extension format with the --restrict-filenames again for underscores instead of spaces. Works typically well as music will have Artist name first usually followed by song title so no need to format.

haven't looked into the --embed-metadata parameter, only imagine it could be useful if it saves the url suffix for youtube link (which you don't want in your filename hopefully)

for my video downloads, i just use this.
alias ydl='yt-dlp -o '%(title)s.%(ext)s' -f bv+ba/b --restrict-filenames' alias mp3='yt-dlp -o '%(title)s.%(ext)s' -f bestaudio -x --audio-format mp3 --embed-thumbnail --restrict-filenames'

Probably bad practice to have single quotes within more single quotes but ran into issues with yt-dlp over using double quotes.  

-Ryan