### PR TITLE
Make otp script more secure + other improvements

### DIFF
--- a/.local/bin/otp
+++ b/.local/bin/otp
@@ -13,27 +13,25 @@ ifinstalled pass pass-otp
 
 dir="${PASSWORD_STORE_DIR}"
 
-choice="$({ echo "🆕add" ; echo "🕙sync-time" ; ls ${dir}/*-otp.gpg ;} | sed "s/.*\///;s/-otp.gpg//" | dmenu -p "Pick a 2FA:")"
+choice="$({ echo "🆕add" ; echo "🕙sync-time" ; ls "$dir"/*-otp.gpg ;} | sed "s/.*\///;s/-otp.gpg//" | dmenu -p "Pick a 2FA:")"
 
 case $choice in
 	🆕add )
-		ifinstalled maim zbar xclip || exit 1
+		ifinstalled maim zbar || exit 1
 
-		temp="$dir/temp.png"
+		temp=$(mktemp -p "$XDG_RUNTIME_DIR" --suffix=.png)
 		otp="otp-test-script"
-		trap 'shred -fu $temp; pass rm $otp' HUP INT QUIT TERM PWR EXIT
+		trap 'rm -f $temp; pass rm -f $otp' HUP INT QUIT TERM PWR EXIT
 
 		notify-send "Scan the image." "Scan the OTP QR code."
 
 		maim -s "$temp" || exit 1
 		info="$(zbarimg -q "$temp")"
 		info="${info#QR-Code:}"
-		issuer="$(echo "$info" | grep -o "issuer=[A-z0-9]\+")"
-		name="${issuer#issuer=}"
 
 		if echo "$info" | pass otp insert "$otp"; then
 			while true ; do
-				export name="$(dmenu -p "Give this One Time Password a one-word name:")"
+				export name="$(echo | dmenu -p "Give this One Time Password a one-word name:")"
 				echo "$name" | grep -q -- "^[A-z0-9-]\+$" && break
 			done
 			pass mv "$otp" "$name-otp"
@@ -41,7 +39,6 @@ case $choice in
 		else
 			notify-send "No OTP data found." "Try to scan the image again more precisely."
 		fi
-
 		;;
 	🕙sync-time )
 		ifinstalled ntp || exit 1


### PR DESCRIPTION
Make a temporary directory in `$XDG_RUNTIME_DIR` instead of `$PASSWORD_STORE_DIR`. 

`$XDG_RUNTIME_DIR` defaults to `/run/user/$uid/`. This directory has the security advantage of only being readable and writable by the current user and being mounted in RAM, causing the screenshot to be fully wiped on shutdown and not needing shred, which doesn't work reliably on SSD's. 

Also quoted `$dir`, for the off chance someone has spaces in their `$PASSWORD_STORE_DIR`.

Removed the check for `xclip` and the `$issuer` and `$name` variables, as they are unused.

If you're wondering why echo is piped into dmenu, on my system dmenu hung when called without the pipe, causing the whole script to freeze.