### PR TITLE
Use ffmpeg for tag script

### DIFF
--- a/.local/bin/tag
+++ b/.local/bin/tag
@@ -13,7 +13,7 @@ Options:
 	-c: comment
 You will be prompted for title, artist, album and track if not given." && exit 1 ;}
 
-while getopts "a:t:A:n:N:d:g:c:f:" o; do case "${o}" in
+while getopts "a:t:A:n:N:d:g:c:" o; do case "${o}" in
 	a) artist="${OPTARG}" ;;
 	t) title="${OPTARG}" ;;
 	A) album="${OPTARG}" ;;
@@ -22,7 +22,6 @@ while getopts "a:t:A:n:N:d:g:c:f:" o; do case "${o}" in
 	d) date="${OPTARG}" ;;
 	g) genre="${OPTARG}" ;;
 	c) comment="${OPTARG}" ;;
-	f) file="${OPTARG}" ;;
 	*) printf "Invalid option: -%s\\n" "$OPTARG" && err ;;
 esac done
 
@@ -30,42 +29,21 @@ shift $((OPTIND - 1))
 
 file="$1"
 
-[ ! -f "$file" ] && echo "Provide file to tag." && err
+temp="$(mktemp -p "$(dirname "$file")")"
+trap 'rm -f $temp' HUP INT QUIT TERM PWR EXIT
 
-[ -z "$title" ] && echo "Enter a title." && read -r title
-[ -z "$artist" ] && echo "Enter an artist." && read -r artist
-[ -z "$album" ] && echo "Enter an album." && read -r album
-[ -z "$track" ] && echo "Enter a track number." && read -r track
+[ ! -f "$file" ] && echo 'Provide file to tag.' && err
 
-case "$file" in
-	*.ogg) echo "Title=$title
-Artist=$artist
-Album=$album
-Track=$track
-Total=$total
-Date=$date
-Genre=$genre
-Comment=$comment" | vorbiscomment -w "$file" ;;
-	*.opus) echo "Title=$title
-Artist=$artist
-Album=$album
-Track=$track
-Total=$total
-Date=$date
-Genre=$genre
-Comment=$comment" | opustags -i -S "$file" ;;
-	*.mp3) eyeD3 -Q --remove-all -a "$artist" -t "$title" -A "$album" -n "$track" \
-		${total:+-N "$total"} \
-		${date:+-Y "$date"} \
-		${genre:+-G "$genre"} \
-		${comment:+-c "$comment"} "$file" ;;
-	*.flac) echo "TITLE=$title
-ARTIST=$artist
-ALBUM=$album
-TRACKNUMBER=$track
-TOTALTRACKS=$total
-DATE=$date
-GENRE=$genre
-DESCRIPTION=$comment" | metaflac --remove-all-tags --import-tags-from=- "$file" ;;
-	*) echo "File type not implemented yet." ;;
-esac
+[ -z "$title" ] && echo 'Enter a title.' && read -r title
+[ -z "$artist" ] && echo 'Enter an artist.' && read -r artist
+[ -z "$album" ] && echo 'Enter an album.' && read -r album
+[ -z "$track" ] && echo 'Enter a track number.' && read -r track
+
+cp -f "$file" "$temp" && ffmpeg -i "$temp" -map 0 -y -codec copy \
+	-metadata title="$title" \
+	-metadata album="$album" \
+	-metadata artist="$artist" \
+	-metadata track="${track}${total:+/"$total"}" \
+	${date:+-metadata date="$date"} \
+	${genre:+-metadata genre="$genre"} \
+	${comment:+-metadata comment="$comment"} "$file"


### PR DESCRIPTION
eyeD3 got orphaned in the AUR, so I looked for an alternative. Apparently ffmpeg also supports the ability to tag audio files, so this pull request replaces all the helper applications with ffmpeg