### PR TITLE
Make sb-forecast and sb-moonphase more robust

### DIFF
--- a/.local/bin/statusbar/sb-forecast
+++ b/.local/bin/statusbar/sb-forecast
@@ -29,7 +29,7 @@ esac
 
 # The test if our forcecast is updated to the day. If it isn't download a new
 # weather report from wttr.in with the above function.
-[ "$(stat -c %y "$weatherreport" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
+[ ! -s "$weatherreport" ] && [ "$(stat -c %y "$weatherreport" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
 	getforecast
 
 showweather

--- a/.local/bin/statusbar/sb-moonphase
+++ b/.local/bin/statusbar/sb-moonphase
@@ -4,7 +4,7 @@
 
 moonfile="${XDG_DATA_HOME:-$HOME/.local/share}/moonphase"
 
-[ "$(stat -c %y "$moonfile" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
+[ ! -s "$moonfile" ] && [ "$(stat -c %y "$moonfile" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
 	{ curl -sf "wttr.in/?format=%m" > "$moonfile" || exit 1 ;}
 
 icon="$(cat "$moonfile")"


### PR DESCRIPTION
Sometimes curl doesn't error, but downloads an empty file instead and still updates the date, causing the rest of the script to fail and not showing the icons on the statusbar. This checks if the downloaded file is not empty before checking if the date is good.