### PR TITLE
Statusbar music improvements and bug fix

### DIFF
--- a/.local/bin/statusbar/sb-mpdup
+++ b/.local/bin/statusbar/sb-mpdup
@@ -3,6 +3,8 @@
 # This loop will update the mpd statusbar module whenever a command changes the
 # music player's status. mpd must be running on X's start for this to work.
 
+pgrep -x 'mpd' || exit
+
 while : ; do
-	mpc idle >/dev/null && kill -45 "$(pidof "${STATUSBAR:-dwmblocks}")" || break
+        mpc idle >/dev/null && pkill -RTMIN+11 "${STATUSBAR:-dwmblocks}"
 done

--- a/.local/bin/statusbar/sb-music
+++ b/.local/bin/statusbar/sb-music
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-filter() { mpc | sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d;/^ERROR/Q" | paste -sd ' ' -;}
+filter() { sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d;/^ERROR/Q" | paste -sd ' ' -;}
 
 pidof -x sb-mpdup >/dev/null 2>&1 || sb-mpdup >/dev/null 2>&1 &
 


### PR DESCRIPTION
On my system there was a bug where if I had connected an external monitor to my laptop, `sb-mpdup` exited immediately causing the music status to not show up in the statusbar. I changed line 7 in `sb-mpdupd` to:

`mpc idle 2>"$HOME/debug.txt" || break`

and rebooted, and in debug.txt it said:

`MPD error: Connection refused`

even though this script does work when no external monitor is connected and only the laptop's monitor is used.

By changing the `break` to checking if mpd is running before entering the while loop, the bug was fixed.
