### PR TITLE
use pamixer again

### DIFF
--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -13,7 +13,7 @@ case $BLOCK_BUTTON in
 	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-[ "$(pamixer --get-mute)" = true ] && echo "m" && exit
+[ "$(pamixer --get-mute)" = true ] && echo "🔇" && exit
 
 vol="$(pamixer --get-volume)"
 

--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -18,10 +18,10 @@ esac
 vol="$(pamixer --get-volume)"
 
 case 1 in
-    $((vol >= 70)) ) icon="🔊" ;;
-    $((vol >= 30)) ) icon="🔉" ;;
-    $((vol >= 1)) ) icon="🔈" ;;
-    * ) echo m && exit ;;
+    	$((vol >= 70)) ) icon="🔊" ;;
+   	$((vol >= 30)) ) icon="🔉" ;;
+    	$((vol >= 1)) ) icon="🔈" ;;
+  	* ) echo 🔇 && exit ;;
 esac
 
 echo "$icon$vol%"

--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -13,26 +13,15 @@ case $BLOCK_BUTTON in
 	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-vol="$(wpctl get-volume @DEFAULT_AUDIO_SINK@)"
+[ "$(pamixer --get-mute)" = true ] && echo "m" && exit
 
-# If muted, print 🔇 and exit.
-[ "$vol" != "${vol%\[MUTED\]}" ] && echo 🔇 && exit
-
-vol="${vol#Volume: }"
-split() {
-	# For ommiting the . without calling and external program.
-	IFS=$2
-	set -- $1
-	printf '%s' "$@"
-}
-vol="$(split "$vol" ".")"
-vol="${vol##0}"
+vol="$(pamixer --get-volume)"
 
 case 1 in
-	$((vol >= 70)) ) icon="🔊" ;;
-	$((vol >= 30)) ) icon="🔉" ;;
-	$((vol >= 1)) ) icon="🔈" ;;
-	* ) echo 🔇 && exit ;;
+    $((vol >= 70)) ) icon="🔊" ;;
+    $((vol >= 30)) ) icon="🔉" ;;
+    $((vol >= 1)) ) icon="🔈" ;;
+    * ) echo m && exit ;;
 esac
 
 echo "$icon$vol%"


### PR DESCRIPTION
fixes #1204 as well as everyone else not using pipe wire. I understand that the dot files are meant to be used with respective packages but even so, how is [this](https://github.com/LukeSmithxyz/voidrice/commit/28a57eb59ec33308ab0e835429e9a0dcb054d07e) more efficient and pamixer is still used earlier in the script so its assuming it works.