### PR TITLE
Update getbib

### DIFF
--- a/.local/bin/getbib
+++ b/.local/bin/getbib
@@ -4,7 +4,7 @@
 if [ -f "$1" ]; then
 	# Try to get DOI from pdfinfo or pdftotext output.
 	doi=$(pdfinfo "$1" | grep -io "doi:.*") ||
-	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*" -m 1) ||
+	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*" -m 1 | sed 's/ //g') ||
 	exit 1
 else
 	doi="$1"


### PR DESCRIPTION
The script does not work with pdf files because most of the pdf files have a space after "DOI:" argument and that space causes curl errors. I have tried this way and it works. 

![image](https://user-images.githubusercontent.com/89175311/194152512-d845dfe3-14d0-427b-9e05-06556ce7edde.png)
