### PR TITLE
Update Getbib Again

### DIFF
--- a/.local/bin/getbib
+++ b/.local/bin/getbib
@@ -4,7 +4,7 @@
 if [ -f "$1" ]; then
 	# Try to get DOI from pdfinfo or pdftotext output.
 	doi=$(pdfinfo "$1" | grep -io "doi:.*") ||
-	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*" -m 1 | sed 's/ //g') ||
+	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*\s*\S*[0-9A-Za-z]" -m 1 ||
 	exit 1
 else
 	doi="$1"

--- a/.local/bin/getbib
+++ b/.local/bin/getbib
@@ -4,7 +4,7 @@
 if [ -f "$1" ]; then
 	# Try to get DOI from pdfinfo or pdftotext output.
 	doi=$(pdfinfo "$1" | grep -io "doi:.*") ||
-	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*" -m 1) ||
+	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*" -m 1 | sed 's/ //g') ||
 	exit 1
 else
 	doi="$1"

--- a/.local/bin/getbib
+++ b/.local/bin/getbib
@@ -4,7 +4,7 @@
 if [ -f "$1" ]; then
 	# Try to get DOI from pdfinfo or pdftotext output.
 	doi=$(pdfinfo "$1" | grep -io "doi:.*") ||
-	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*\s*\S*[0-9A-Za-z]" -m 1 ||
+	doi=$(pdftotext "$1" 2>/dev/null - | grep -io "doi:.*\s*\S*[0-9A-Za-z]" -m 1) ||
 	exit 1
 else
 	doi="$1"


### PR DESCRIPTION
Hi Luke! getbib script is amazing for academic work. From the last pull request of mine I understand that you don't want to use another program while we can do the same thing with just one program (just grep without sed).

The error is sometimes we get a "." at the end of the doi. This time I've done my homework by watching your video called "Regular Expressions: Regex" and done the changes accordingly :)

Output of pdftotext | grep, Before the change: `doi:10.1016/j.cell.2012.04.034.`
Output of pfttotext | grep, After the change: `doi:10.1016/j.cell.2012.04.034`