### PR TITLE
Make sd script work with lf file manager too

### DIFF
--- a/.local/bin/sd
+++ b/.local/bin/sd
@@ -5,6 +5,7 @@
 PID=$(xprop -id "$(xprop -root | xprop -root | sed -n "/_NET_ACTIVE_WINDOW/ s/^.*# // p")" | sed -n "/PID/ s/^.*= // p")
 PID="$(pstree -lpA "$PID")"
 PID="${PID##*"${SHELL##*/}"(}"
+PID="${PID#*lf(}"
 PID="${PID%%)*}"
 cd "$(readlink /proc/"$PID"/cwd)" || return 1
 "$TERMINAL"


### PR DESCRIPTION
Now sd script can open a terminal window in the same directory as the currently active lf file manager window