### PR TITLE
Fix Sioux Falls

### DIFF
--- a/.local/bin/statusbar/sb-doppler
+++ b/.local/bin/statusbar/sb-doppler
@@ -55,7 +55,7 @@ US: KUDX: Rapid City, SD
 US: KRIW: Riverton, WY
 US: KSGF: Springfield, MO
 US: KLSX: St. LOUIS, MO
-US: KFSD: Sioux Falls, IA
+US: KFSD: Sioux Falls, SD
 US: KTWX: Topeka, KS
 US: KICT: Wichita, KS
 US: KVWX: Paducah, KY


### PR DESCRIPTION
Sioux Falls is in South Dakota, not Iowa