### PR TITLE
Enabling Gruvbox Theme & True Color Support for Nvim

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -18,11 +18,11 @@ Plug 'jreybert/vimagit'
 Plug 'vimwiki/vimwiki'
 Plug 'vim-airline/vim-airline'
 Plug 'tpope/vim-commentary'
-Plug 'ap/vim-css-color'
+Plug 'morhetz/gruvbox'
 call plug#end()
 
 set title
-set bg=light
+set bg=dark
 set go=a
 set mouse=a
 set nohlsearch
@@ -31,6 +31,15 @@ set noshowmode
 set noruler
 set laststatus=0
 set noshowcmd
+
+let &t_8f="\<Esc>[38;2;%lu;%lu;%lum"
+let &t_8b="\<Esc>[48;2;%lu;%lu;%lum"
+set termguicolors
+
+let g:gruvbox_transparent_bg='1'
+let g:gruvbox_contrast_dark='hard'
+colorscheme gruvbox
+autocmd VimEnter * hi Normal ctermbg=NONE guibg=NONE
 
 " Some basics:
 	nnoremap c "_c


### PR DESCRIPTION
Gruvbox better suits the system since terminal's color scheme already is Gruvbox.

The changes also enable the truecolor support which is natively supported by st. The colors look better and distinguishable this way.

The last line with autocmd is for transparency. Without it, transparency wouldn't work.

I hugely recommend trying this out. You'll maybe commit the changes later.