### PR TITLE
Linkhandler 255 character limit

### DIFF
--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -12,13 +12,16 @@ else
 	url="$1"
 fi
 
+link=$(echo $1 | sed 's/.*\///;s/%20/ /g')
+[ ${#link} -ge 255 ] && link=$(echo $link | cut -c 100-)
+
 case "$url" in
 	*mkv|*webm|*mp4|*youtube.com/watch*|*youtube.com/playlist*|*youtu.be*|*hooktube.com*|*bitchute.com*|*videos.lukesmith.xyz*|*odysee.com*)
 		setsid -f mpv -quiet "$url" >/dev/null 2>&1 ;;
 	*png|*jpg|*jpe|*jpeg|*gif)
-		curl -sL "$url" > "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")" && sxiv -a "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
+		curl -sL "$url" > "/tmp/$link" && sxiv -a "/tmp/$link"  >/dev/null 2>&1 & ;;
 	*pdf|*cbz|*cbr)
-		curl -sL "$url" > "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
+		curl -sL "$url" > "/tmp/$link" && zathura "/tmp/$link"  >/dev/null 2>&1 & ;;
 	*mp3|*flac|*opus|*mp3?source*)
 		qndl "$url" 'curl -LO'  >/dev/null 2>&1 ;;
 	*)


### PR DESCRIPTION
Sometimes link passed to linkhandler can be longer than 255 characters long (if link language is Cyrillic for example or when link is generated from image tags), thus it cannot display images or PDFs properly due to internal limit on name length. This small check uses "cut" from GNU coreutils to shorten the URL to 100 chars if it is longer than 255.