### PR TITLE
Make the shell remember your ssh key

### DIFF
--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -27,7 +27,8 @@ _comp_options+=(globdots)		# Include hidden files.
 # vi mode
 bindkey -v
 export KEYTIMEOUT=1
-
+# Use keychain to load ssh-agent
+eval `keychain --eval --quiet --noask --agents ssh id_rsa ~/.ssh/id_rsa`
 # Use vim keys in tab complete menu:
 bindkey -M menuselect 'h' vi-backward-char
 bindkey -M menuselect 'k' vi-up-line-or-history


### PR DESCRIPTION
In the video [Setting up a Website...](https://youtu.be/3dIVesHEAzc?t=555) Luke talks about not having to type the password every time you ssh into your server. 
However when you follow the tutorial it prompts the password for the ssh-key every time instead, this line removes that need to ask every time and only once.