### PR TITLE
Avoid expansion of file path containing spaces

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -115,8 +115,8 @@ map <c-s> set hidden!
 map <enter> shell
 map x $$f
 map X !$f
-map o &mimeopen $f
-map O $mimeopen --ask $f
+map o &mimeopen "$f"
+map O $mimeopen --ask "$f"
 
 map A rename # at the very end
 map c push A<c-u> # new rename


### PR DESCRIPTION
Prevent file paths containing space characters to be passed to `mimeopen` as a vector of incorrect paths. 