### PR TITLE
Stop trapping SIGINT to allow further use of Ctrl+C once lfcd is closed

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -115,8 +115,8 @@ map <c-s> set hidden!
 map <enter> shell
 map x $$f
 map X !$f
-map o &mimeopen $f
-map O $mimeopen --ask $f
+map o &mimeopen "$f"
+map O $mimeopen --ask "$f"
 
 map A rename # at the very end
 map c push A<c-u> # new rename

--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -115,8 +115,8 @@ map <c-s> set hidden!
 map <enter> shell
 map x $$f
 map X !$f
-map o &mimeopen "$f"
-map O $mimeopen --ask "$f"
+map o &mimeopen $f
+map O $mimeopen --ask $f
 
 map A rename # at the very end
 map c push A<c-u> # new rename

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -54,7 +54,7 @@ preexec() { echo -ne '\e[5 q' ;} # Use beam shape cursor for each new prompt.
 # Use lf to switch directories and bind it to ctrl-o
 lfcd () {
     tmp="$(mktemp -uq)"
-    trap 'rm -f $tmp >/dev/null 2>&1' HUP INT QUIT TERM PWR EXIT
+    trap 'rm -f $tmp >/dev/null 2>&1' HUP QUIT TERM PWR EXIT
     lf -last-dir-path="$tmp" "$@"
     if [ -f "$tmp" ]; then
         dir="$(cat "$tmp")"

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -54,7 +54,7 @@ preexec() { echo -ne '\e[5 q' ;} # Use beam shape cursor for each new prompt.
 # Use lf to switch directories and bind it to ctrl-o
 lfcd () {
     tmp="$(mktemp -uq)"
-    trap 'rm -f $tmp >/dev/null 2>&1 && trap - HUP INT QUIT TERM PWR EXIT' HUP QUIT TERM PWR EXIT
+    trap 'rm -f $tmp >/dev/null 2>&1 && trap - HUP INT QUIT TERM PWR EXIT' HUP INT QUIT TERM PWR EXIT
     lf -last-dir-path="$tmp" "$@"
     if [ -f "$tmp" ]; then
         dir="$(cat "$tmp")"

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -54,7 +54,7 @@ preexec() { echo -ne '\e[5 q' ;} # Use beam shape cursor for each new prompt.
 # Use lf to switch directories and bind it to ctrl-o
 lfcd () {
     tmp="$(mktemp -uq)"
-    trap 'rm -f $tmp >/dev/null 2>&1' HUP QUIT TERM PWR EXIT
+    trap 'rm -f $tmp >/dev/null 2>&1 && trap - HUP INT QUIT TERM PWR EXIT' HUP QUIT TERM PWR EXIT
     lf -last-dir-path="$tmp" "$@"
     if [ -f "$tmp" ]; then
         dir="$(cat "$tmp")"


### PR DESCRIPTION
I was annoyed by the fact that once I close `lfcd`, I could not longer press `Ctrl+C` to interrupt commands. This PR untraps the signals once `lfcd` quit.