### PR TITLE
add TERMINAL_PROG variable

### DIFF
--- a/.config/shell/profile
+++ b/.config/shell/profile
@@ -13,6 +13,7 @@ unsetopt PROMPT_SP
 # Default programs:
 export EDITOR="nvim"
 export TERMINAL="st"
+export TERMINAL_PROG="st"
 export BROWSER="librewolf"
 
 # ~/ Clean-up:


### PR DESCRIPTION
used in programs like `xtrace` (line 172 `/usr/bin/xtrace`)