### PR TITLE
fix epub preview not working

### DIFF
--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -26,7 +26,6 @@ case "$(file --dereference --brief --mime-type -- "$1")" in
 	text/html) lynx -width="$4" -display_charset=utf-8 -dump "$1" ;;
 	text/troff) man ./ "$1" | col -b ;;
 	text/* | */xml | application/json) bat --terminal-width "$(($4-2))" -f "$1" ;;
-	application/*zip) atool --list -- "$1" ;;
 	audio/* | application/octet-stream) mediainfo "$1" || exit 1 ;;
 	video/* )
 		CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/lf/thumb.$(stat --printf '%n\0%i\0%F\0%s\0%W\0%Y' -- "$(readlink -f "$1")" | sha256sum | cut -d' ' -f1)"
@@ -43,6 +42,7 @@ case "$(file --dereference --brief --mime-type -- "$1")" in
 		[ ! -f "$CACHE.jpg" ] && gnome-epub-thumbnailer "$1" "$CACHE.jpg"
 		image "$CACHE.jpg" "$2" "$3" "$4" "$5" "$1"
 		;;
+	application/*zip) atool --list -- "$1" ;;
 	*opendocument*) odt2txt "$1" ;;
 	application/pgp-encrypted) gpg -d -- "$1" ;;
 esac


### PR DESCRIPTION
Fix epub preview not working which has MIME-type `application/epub+zip`. The script match pattern `application/*zip` first, instead of previewing the image.