### PR TITLE
Various bug fixes and improvements for sd script

### DIFF
--- a/.local/bin/sd
+++ b/.local/bin/sd
@@ -2,8 +2,21 @@
 
 # Open a terminal window in the same directory as the currently active window.
 
-PID=$(xprop -id "$(xprop -root | sed -n "/_NET_ACTIVE_WINDOW/ s/^.*# // p")" | sed -n "/PID/ s/^.*= // p")
-PID=$(pstree -lpATna "$PID" | grep -v '\-\(lf,[0-9]\+ -server\|(st-urlhandler,[0-9]\+)\|xclip,[0-9]\+\)' | sed '$s/.*,\([0-9]\+\).*/\1/;t;d')
-cwd=$(readlink /proc/"$PID"/cwd)
+windowPID=$(xprop -id "$(xprop -root | sed -n "/_NET_ACTIVE_WINDOW/ s/^.*# // p")" | sed -n "/PID/ s/^.*= // p")
+PIDlist=$(pstree -lpATna "$windowPID" | sed -En 's/.*,([0-9]+).*/\1/p' | tac)
+for PID in $PIDlist; do
+	cmdline=$(ps -o args= -p "$PID")
+	process_group_leader=$(ps -o comm= -p "$(ps -o pgid= -p "$PID" | tr -d ' ')")
+	cwd=$(readlink /proc/"$PID"/cwd)
+	# zsh and lf won't be ignored even if it shows ~ or /
+	case "$cmdline" in
+		'lf -server') continue ;;
+		"${SHELL##*/}"|'lf'|'lf '*) break ;;
+	esac
+	# git (and its sub-processes) will show the root of a repository instead of the actual cwd, so they're ignored
+	[ "$process_group_leader" = 'git' ] || [ ! -d "$cwd" ] && continue
+	# This is to ignore programs that show ~ or / instead of the actual working directory
+	[ "$cwd" != "$HOME" ] && [ "$cwd" != '/' ] && break
+done
 [ "$PWD" != "$cwd" ] && [ -d "$cwd" ] && { cd "$cwd" || exit 1; }
 "$TERMINAL"


### PR DESCRIPTION
* Programs that show ~/ or / instead of the actual working directory are now ignored by the script (except for zsh & lf where its correct). This will fix bugs where sd opens your home folder instead of the current working directory.
* This also removes the need for manually excluding all programs that don't show the correct cwd.
* git (and its sub-processes) will show the root of a repository instead of the actual cwd, so they're ignored too.