### PR TITLE
Don't stop mounter script on ls error

### DIFF
--- a/.local/bin/mounter
+++ b/.local/bin/mounter
@@ -16,7 +16,7 @@ alldrives="$(lsblk -rpo "uuid,name,type,size,label,mountpoint,fstype")"
 # Get all LUKS drives
 allluks="$(echo "$alldrives" | grep crypto_LUKS)"
 # Get a list of the LUKS drive UUIDs already decrypted.
-decrypted="$(ls /dev/disk/by-id/dm-uuid-CRYPT-LUKS2-* | sed "s|.*LUKS2-||;s|-.*||")"
+decrypted="$(ls /dev/disk/by-id/dm-uuid-CRYPT-LUKS2-* | sed "s|.*LUKS2-||;s|-.*||")" || true
 # Functioning for formatting drives correctly for dmenu:
 filter() { sed "s/ /:/g" | awk -F':' '$7==""{printf "%s%s (%s) %s\n",$1,$3,$5,$6}' ; }
 

--- a/.local/bin/mounter
+++ b/.local/bin/mounter
@@ -14,9 +14,9 @@ phones="$(simple-mtpfs -l 2>/dev/null | sed "s/^/📱/")"
 # Check for drives.
 alldrives="$(lsblk -rpo "uuid,name,type,size,label,mountpoint,fstype")"
 # Get all LUKS drives
-allluks="$(echo "$alldrives" | grep crypto_LUKS)"
+allluks="$(echo "$alldrives" | grep crypto_LUKS)" || true
 # Get a list of the LUKS drive UUIDs already decrypted.
-decrypted="$(ls /dev/disk/by-id/dm-uuid-CRYPT-LUKS2-* | sed "s|.*LUKS2-||;s|-.*||")" || true
+decrypted="$(ls /dev/disk/by-id/dm-uuid-CRYPT-LUKS2-* | sed "s|.*LUKS2-||;s|-.*||")"
 # Functioning for formatting drives correctly for dmenu:
 filter() { sed "s/ /:/g" | awk -F':' '$7==""{printf "%s%s (%s) %s\n",$1,$3,$5,$6}' ; }
 


### PR DESCRIPTION
If no decrypted LUKS drives are found, the script errors with `ls: cannot access '/dev/disk/by-id/dm-uuid-CRYPT-LUKS2-*': No such file or directory` and stops, this makes sure the error doesn't stop the script.