### PR TITLE
remove adding newline

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -117,7 +117,6 @@ set noshowcmd
  	autocmd BufWritePre * let currPos = getpos(".")
 	autocmd BufWritePre * %s/\s\+$//e
 	autocmd BufWritePre * %s/\n\+\%$//e
-	autocmd BufWritePre *.[ch] %s/\%$/\r/e
   	autocmd BufWritePre * cal cursor(currPos[1], currPos[2])
 
 " When shortcut files are updated, renew bash and ranger configs with new material:


### PR DESCRIPTION
`eol`or `endofline` is set on by default in vim so there is no need for this. fixes #1256