### PR TITLE
Fix mouse issue in firefox, add avif icon and add DK & SE to dopplar

### DIFF
--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -42,3 +42,6 @@ user_pref("network.http.referer.XOriginPolicy", 0);
 
 // Disable Firefox sync and its menu entries
 user_pref("identity.fxaccounts.enabled", false);
+
+// Fix the issue where right mouse button instantly clicks.
+user_pref("ui.context_menus.after_mouseup", true);

--- a/.config/lf/icons
+++ b/.config/lf/icons
@@ -9,6 +9,7 @@ ex	🎯
 *.mom	✍
 *.me	✍
 *.ms	✍
+*.avif 🖼
 *.png	🖼
 *.webp	🖼
 *.ico	🖼

--- a/.local/bin/statusbar/sb-doppler
+++ b/.local/bin/statusbar/sb-doppler
@@ -188,7 +188,9 @@ EU: SCAN: Scandinavia
 EU: ALPS: The Alps
 EU: NL: The Netherlands
 EU: DE: Germany
+EU: DK: Denmark
 EU: SP: Spain
+EU: SE: Sweden
 EU: FR: France
 EU: IT: Italy
 EU: PL: Poland


### PR DESCRIPTION
###  Fix issue with right click in window managers

Mousebros...

This issue might disappear over time as more packages are installed, but i had this issue when i first installed LARBS and this fixed it.
Also mentioned in the  [arch wiki](https://wiki.archlinux.org/title/firefox#Right_mouse_button_instantly_clicks_the_first_option_in_window_managers
)

###  Add avif icon

### Add Denmark and Sweden to weather radar


