### PR TITLE
Automate remaps upon new keyboard

### DIFF
--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -8,7 +8,7 @@ setbg &			# set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources & xrdbpid=$!	# Uncomment to use Xresources colors/settings on startup
 remaps &		# run the remaps script, switching caps/esc and more; check it for more info
 
-autostart="mpd xcompmgr dunst unclutter pipewire"
+autostart="mpd xcompmgr dunst unclutter pipewire remapd"
 
 for program in $autostart; do
 	pidof -s "$program" || "$program" &

--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -1,0 +1,6 @@
+#!/bin/sh
+while : ; do
+    dmesg -W -f kern | grep "input:" -q
+    sleep 1
+    remaps
+done


### PR DESCRIPTION
This PR would make remaps be run automatically when a new keyboard is plugged in. Note that if the script will be run unprivileged, you will have to add `kernel.dmesg_restrict = 0` to /etc/sysctl or to a file in /etc/sysctl.d. This allows unprivileged reading of dmesg which probably fits the threat model of the majority of desktop users.

`dmesg -W -f kern | grep "input:" -q` blocks until dmesg writes a line containing "input:", which happens when a keyboard is plugged in. I'm sure you could refine this grep statement, but I left it as general as possible.