### PR TITLE
Add support for avif in lf

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -34,7 +34,7 @@ cmd open ${{
         text/*|application/json|inode/x-empty|application/x-subrip) $EDITOR $fx;;
 	image/x-xcf) setsid -f gimp $f >/dev/null 2>&1 ;;
 	image/svg+xml) display -- $f ;;
-	image/*) rotdir $f | grep -i "\.\(png\|jpg\|jpeg\|gif\|webp\|tif\|ico\)\(_large\)*$" |
+	image/*) rotdir $f | grep -i "\.\(png\|jpg\|jpeg\|gif\|webp\|avif\|tif\|ico\)\(_large\)*$" |
 		setsid -f sxiv -aio 2>/dev/null | while read -r file; do
 			[ -z "$file" ] && continue
 			lf -remote "send select \"$file\""

--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -22,6 +22,9 @@ ifub() {
 # be regenerated once seen.
 
 case "$(file --dereference --brief --mime-type -- "$1")" in
+	image/avif) CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/lf/thumb.$(stat --printf '%n\0%i\0%F\0%s\0%W\0%Y' -- "$(readlink -f "$1")" | sha256sum | cut -d' ' -f1)"
+		[ ! -f "$CACHE" ] && convert "$1" "$CACHE.jpg"
+		image "$CACHE.jpg" "$2" "$3" "$4" "$5" "$1" ;;
 	image/*) image "$1" "$2" "$3" "$4" "$5" "$1" ;;
 	text/html) lynx -width="$4" -display_charset=utf-8 -dump "$1" ;;
 	text/troff) man ./ "$1" | col -b ;;


### PR DESCRIPTION
With this update, lf is now capable of displaying *.avif images seamlessly. This feature is made possible through the conversion of the avif image to a *.jpg format in the cache, which is then displayed using ueberzug.

Here is an image showing lf displaying an *.avif image
![picture of lf displaying an avif image](https://user-images.githubusercontent.com/29478339/217254042-55f3f62d-2629-4d9b-bb18-6f0b8a7728aa.png)


This approach not only enables lf to support avif images but also future image formats that may not be supported by ueberzug. If there are any additional image formats that need support, they can be easily added to lf in the future.

If you'd like to see this feature in action, feel free to test it out using the avif image linked [here](https://risgaard.xyz/pix/figterJet.avif)