### PR TITLE
Python ~/ cleanup

### DIFF
--- a/.config/python/pythonrc
+++ b/.config/python/pythonrc
@@ -1,0 +1,2 @@
+import readline
+readline.write_history_file = lambda *args: None

--- a/.config/shell/profile
+++ b/.config/shell/profile
@@ -40,6 +40,7 @@ export UNISON="$XDG_DATA_HOME/unison"
 export HISTFILE="$XDG_DATA_HOME/history"
 export MBSYNCRC="$XDG_CONFIG_HOME/mbsync/config"
 export ELECTRUMDIR="$XDG_DATA_HOME/electrum"
+export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/pythonrc"
 
 # Other program settings:
 export DICS="/usr/share/stardict/dic/"


### PR DESCRIPTION
## Description
This PR adds an environmental variable named `PYTHONSTARTUP` that points to a file in the `~/.config` directory. This file will contain the startup script for Python and will be executed whenever the Python interpreter is started. 

## Benefits
- Reduces the amount of clutter in the home directory by preventing the creation of a history file.
- Preserves the functionality of the Python interpreter's history, unlike other methods that completely disable it.


> Check out [this](https://stackoverflow.com/questions/62063414/how-to-disable-python-history-saving) for more information.