### PR TITLE
Clean up remapd

### DIFF
--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -2,8 +2,10 @@
 
 # Rerun the remaps script whenever a new input device is added.
 
-while : ; do
-    remaps
-    dmesg -W -f kern | grep "input:" -q
-    sleep 1
+trap "rm -f /tmp/udev_pipe" HUP INT QUIT ILL TRAP BUS TERM
+mkfifo -m 600 /tmp/udev_pipe
+udevadm monitor -u -t seat -s input -s usb >>/tmp/udev_pipe &
+while :; do
+	grep -q "add" /tmp/udev_pipe && grep -q " bind" /tmp/udev_pipe
+	remaps us:dvorak
 done

--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -2,7 +2,7 @@
 
 # Rerun the remaps script whenever a new input device is added.
 
-trap "rm -f /tmp/udev_pipe" HUP INT QUIT ILL TRAP BUS TERM
+trap "rm -f /tmp/udev_pipe; exit" HUP INT QUIT ILL TRAP BUS TERM
 mkfifo -m 600 /tmp/udev_pipe
 udevadm monitor -u -t seat -s input -s usb >>/tmp/udev_pipe &
 while :; do

--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -2,10 +2,9 @@
 
 # Rerun the remaps script whenever a new input device is added.
 
-trap "rm -f /tmp/udev_pipe; exit" HUP INT QUIT ILL TRAP BUS TERM
-mkfifo -m 600 /tmp/udev_pipe
-udevadm monitor -u -t seat -s input -s usb >>/tmp/udev_pipe &
 while :; do
-	grep -q "add" /tmp/udev_pipe && grep -q " bind" /tmp/udev_pipe
+    udevadm monitor -u -t seat -s input -s usb | grep --line-buffer -m1 -P '[^un]bind'
+    sleep 1
 	remaps us:dvorak
 done
+


### PR DESCRIPTION
I found a much better way of doing this, without a potentially too short sleep. This script waits for an input to be added, and then waits for a usb device to be bound. The remaps script can be run as soon as the USB device is bound. These changes should improve the reliability of the script and maybe even decrease latency. This way of doing things also doesn't require any changes to /etc/sysctl.conf.