### PR TITLE
unmounter: prompt to eject drive if possible

### DIFF
--- a/.local/bin/unmounter
+++ b/.local/bin/unmounter
@@ -23,6 +23,17 @@ notify-send "Device unmounted." "$chosen has been unmounted."
 # Close the chosen drive if decrypted.
 cryptid="$(echo "$lsblkoutput" | grep "/${chosen#*/}$")"
 cryptid="${cryptid%% *}"
-test -b /dev/mapper/"${cryptid##*/}"
-sudo -A cryptsetup close "$cryptid"
-notify-send "🔒Device dencryption closed." "Drive is now securely locked again."
+
+test -b /dev/mapper/"${cryptid##*/}" &&
+	sudo -A cryptsetup close "$cryptid" &&
+	notify-send "🔒Device dencryption closed." "Drive is now securely locked again."
+
+# Ask to eject drive if possible.
+mntline=$(echo "$lsblkoutput" | tac | grep -m1 -n "/${chosen#*/}" | cut -d':' -f1)
+[ -n "$mntline" ] &&
+	devlabel=$(echo "$lsblkoutput" | tac | tail -n +"$mntline" | grep -m1 '[^ ]* disk' | cut -d'/' -f3 | cut -d' ' -f1) &&
+	samedrivemounts=$(echo "$lsblkoutput" | tac | awk "\$1~/$devlabel/&&!devfound{devfound=1;cnt=0}devfound{if(\$2~/disk/||cnt>1){print cnt;exit}if(\$4){cnt+=1}}") &&
+	[ "$samedrivemounts" = 1 ] &&
+		[ $(printf "No\nYes" | dmenu -p 'Device fully unmounted. Eject this drive?') == 'Yes' ] &&
+			sudo -A sh -c "echo 'offline' > /sys/block/$devlabel/device/state; echo '1' > /sys/block/$devlabel/device/delete" &&
+			notify-send "Device ejected." "Drive can now be removed safely."

--- a/.local/bin/unmounter
+++ b/.local/bin/unmounter
@@ -32,8 +32,8 @@ test -b /dev/mapper/"${cryptid##*/}" &&
 mntline=$(echo "$lsblkoutput" | tac | grep -m1 -n "/${chosen#*/}" | cut -d':' -f1)
 [ -n "$mntline" ] &&
 	devlabel=$(echo "$lsblkoutput" | tac | tail -n +"$mntline" | grep -m1 '[^ ]* disk' | cut -d'/' -f3 | cut -d' ' -f1) &&
-	samedrivemounts=$(echo "$lsblkoutput" | tac | awk '$1~/'"$devlabel"'/&&!cnt{cnt=1}cnt{if($2~/disk/||cnt>2){cnt-=1;print cnt;exit}if($4){cnt+=1}}') &&
+	samedrivemounts=$(echo "$lsblkoutput" | tac | awk '!cnt&&$1~/'"$devlabel"'/{cnt=1}cnt{if(cnt>2||$2~/disk/){cnt-=1;print cnt;exit}if($4){cnt+=1}}') &&
 	[ "$samedrivemounts" = 1 ] &&
-		[ $(printf "No\nYes" | dmenu -p 'Device fully unmounted. Eject this drive?') == 'Yes' ] &&
+		[ "$(printf "No\nYes" | dmenu -p 'Device fully unmounted. Eject this drive?')" = 'Yes' ] &&
 			sudo -A sh -c "echo offline > /sys/block/$devlabel/device/state; echo 1 > /sys/block/$devlabel/device/delete" &&
 			notify-send "Device ejected." "Drive can now be removed safely."

--- a/.local/bin/unmounter
+++ b/.local/bin/unmounter
@@ -32,8 +32,8 @@ test -b /dev/mapper/"${cryptid##*/}" &&
 mntline=$(echo "$lsblkoutput" | tac | grep -m1 -n "/${chosen#*/}" | cut -d':' -f1)
 [ -n "$mntline" ] &&
 	devlabel=$(echo "$lsblkoutput" | tac | tail -n +"$mntline" | grep -m1 '[^ ]* disk' | cut -d'/' -f3 | cut -d' ' -f1) &&
-	samedrivemounts=$(echo "$lsblkoutput" | tac | awk "\$1~/$devlabel/&&!devfound{devfound=1;cnt=0}devfound{if(\$2~/disk/||cnt>1){print cnt;exit}if(\$4){cnt+=1}}") &&
+	samedrivemounts=$(echo "$lsblkoutput" | tac | awk '$1~/'"$devlabel"'/&&!cnt{cnt=1}cnt{if($2~/disk/||cnt>2){cnt-=1;print cnt;exit}if($4){cnt+=1}}') &&
 	[ "$samedrivemounts" = 1 ] &&
 		[ $(printf "No\nYes" | dmenu -p 'Device fully unmounted. Eject this drive?') == 'Yes' ] &&
-			sudo -A sh -c "echo 'offline' > /sys/block/$devlabel/device/state; echo '1' > /sys/block/$devlabel/device/delete" &&
+			sudo -A sh -c "echo offline > /sys/block/$devlabel/device/state; echo 1 > /sys/block/$devlabel/device/delete" &&
 			notify-send "Device ejected." "Drive can now be removed safely."


### PR DESCRIPTION
Whenever the last mount point of a drive gets unmounted, prompt to fully eject the drive as well. Mostly useful for external hard drives, as this gracefully stops them from spinning. Doesn't prompt if any partition of the device is still mounted somewhere.

It doesn't prompt to eject when unmounting an Android device, and I've also tested it to work when unmounting LUKS drives, even if some of the mounted partitions of the drive are encrypted and some not.

It might also be possible to do the ejecting passwordless, but I haven't checked yet.