### PR TITLE
Fixed android device not mounting to root owned directories

### DIFF
--- a/.local/bin/mounter
+++ b/.local/bin/mounter
@@ -87,7 +87,7 @@ case "$chosen" in
 		echo "OK" | dmenu -i -p "Tap Allow on your phone if it asks for permission and then press enter"
 		chosen="${chosen%%:*}"
 		chosen="${chosen:1}"	# This is a bashism.
-		simple-mtpfs --device "$chosen" "$mp"
+		sudo -A simple-mtpfs -o allow_other --device "$chosen" "$mp"
 		notify-send "🤖 Android Mounted." "Android device mounted to $mp."
 		;;
 esac


### PR DESCRIPTION
Without this you wouldn't be able to mount android devices to `/mnt /media` or any other root directory this fixes that and the `-o allow_other` flag allows users other than root to read/write to the mounted directory.