### PR TITLE
Made mounter not show already mounted android devices in the mounting prompt

### DIFF
--- a/.local/bin/mounter
+++ b/.local/bin/mounter
@@ -11,6 +11,9 @@ set -e
 
 # Check for phones.
 phones="$(simple-mtpfs -l 2>/dev/null | sed "s/^/📱/")"
+for NUMBER in $(echo "$phones" | sed -rn 's/.([0-9]).*/\1/gp'); do
+	[[ $(sed -rn 's/simple-mtpfs-([0-9]).*/\1/gp' /etc/mtab) = $NUMBER ]] && phones="$(echo "$phones" | sed "/$NUMBER: .*/d")"
+done
 # Check for drives.
 lsblkoutput="$(lsblk -rpo "uuid,name,type,size,label,mountpoint,fstype")"
 # Get all LUKS drives
@@ -94,7 +97,7 @@ case "$chosen" in
 		getmount
 		chosen="${chosen%%:*}"
 		chosen="${chosen:1}"	# This is a bashism.
-		sudo -A simple-mtpfs -o allow_other --device "$chosen" "$mp"
+		sudo -A simple-mtpfs -o allow_other -o fsname="simple-mtpfs-$chosen" --device "$chosen" "$mp"
 		notify-send "🤖 Android Mounted." "Android device mounted to $mp."
 		;;
 esac


### PR DESCRIPTION
This does one of the items from the TODO list although it still has the problems i mentioned in my [issue](https://github.com/LukeSmithxyz/voidrice/issues/1277), and sorry if this is not very efficient and the excessive use of echo this is my level of bash scripting at the moment.