### PR TITLE
maimpick: hide cursor when selecting area

### DIFF
--- a/.local/bin/maimpick
+++ b/.local/bin/maimpick
@@ -9,10 +9,10 @@ output="$(date '+%y%m%d-%H%M-%S').png"
 xclip_cmd="xclip -sel clip -t image/png"
 
 case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
-    "a selected area") maim -s pic-selected-"${output}" ;;
+    "a selected area") maim -u -s pic-selected-"${output}" ;;
     "current window") maim -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"${output}" ;;
     "full screen") maim -q -d 0.2 pic-full-"${output}" ;;
-    "a selected area (copy)") maim -s | ${xclip_cmd} ;;
+    "a selected area (copy)") maim -u -s | ${xclip_cmd} ;;
     "current window (copy)") maim -q -d 0.2 -i "$(xdotool getactivewindow)" | ${xclip_cmd} ;;
     "full screen (copy)") maim -q -d 0.2 | ${xclip_cmd} ;;
 esac


### PR DESCRIPTION
Normally when making a screenshot of an area there's still a bit of the cursor that can be seen, this hides it.