### PR TITLE
dmenuunicode: don't use variables in the printf format string

### DIFF
--- a/.local/bin/dmenuunicode
+++ b/.local/bin/dmenuunicode
@@ -13,6 +13,6 @@ chosen=$(cut -d ';' -f1 ~/.local/share/larbs/chars/* | dmenu -i -l 30 | sed "s/ 
 if [ -n "$1" ]; then
 	xdotool type "$chosen"
 else
-	printf "$chosen" | xclip -selection clipboard
+	printf "%s" "$chosen" | xclip -selection clipboard
 	notify-send "'$chosen' copied to clipboard." &
 fi


### PR DESCRIPTION
It works but the good practice is to use `printf "..%s.." "$foo"` see https://www.shellcheck.net/wiki/SC2059