### PR TITLE
dbus environment variables

### DIFF
--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -6,7 +6,7 @@
 xrandr --dpi 96		# Set DPI. User may want to use a larger number for larger screens.
 setbg &			# set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources & xrdbpid=$!	# Uncomment to use Xresources colors/settings on startup
-
+dbus-update-activation-environment --all
 autostart="mpd xcompmgr dunst unclutter pipewire remapd"
 
 for program in $autostart; do


### PR DESCRIPTION
This is more or less an [ old pull request ](https://github.com/LukeSmithxyz/voidrice/pull/446#issue-548393603)

Gnome-keyring needs the dbus variables to work properly, and can cause problems where passwords aren't remembered so the user have to login every time he uses an application. The issue and solution is also mentioned in the [Arch Wiki ](https://wiki.archlinux.org/title/GNOME/Keyring#Launching_gnome-keyring-daemon_outside_desktop_environments_(KDE,_GNOME,_XFCE,_...)) 
 
It works on my machine after i added this. 