### PR TITLE
Update sb-iplocate

### DIFF
--- a/.local/bin/statusbar/sb-iplocate
+++ b/.local/bin/statusbar/sb-iplocate
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-# Gets your public ip address checks which country you are in and
-# displays that information in the statusbar
+# Displays the flag of the country you are in based on your public ip adress
 #
 # https://www.maketecheasier.com/ip-address-geolocation-lookups-linux/
 
 ifinstalled "geoip" || exit
+
 addr="$(curl ifconfig.me 2>/dev/null)" || exit
-grep "flag: " "${XDG_DATA_HOME:-$HOME/.local/share}/larbs/emoji" | grep "$(geoiplookup "$addr" | sed 's/.*, //')" | sed "s/flag: //;s/;.*//"
+country="$(geoiplookup "$addr" | sed -e 's/^[^,]*, //' -e 's/,.*$//')" # Keep only between 1st and 2nd comma
+grep "flag: $country" "${XDG_DATA_HOME:-$HOME/.local/share}/larbs/chars/emoji" | 
+  sed 's/flag:.*//' # Remove everything from 'flag:' onward


### PR DESCRIPTION
## Changes
- Improved description
  More concise, no mention of the statusbar, since we can tell by the `sb-` part.
- Handle countries with a comma in their name
  ```sh
  geoiplookup "1.11.0.0"
  GeoIP Country Edition: KR, Korea, Republic of
  ```
  Now, we match "Korea", but previously we matched "Republic of"
- Extracted `country` variable for readability
- Change reference from `~/.local/share/larbs/emoji` to `~/.local/share/larbs/chars/emoji`
  These files are identical, but the 2nd one is also used by `dmenuunicode`, and is updated more recently. This change renders the first file, as far as I know, useless and should probably be removed.
- Added comments regarding the regex
## How to test
- Go to `https://lite.ip2location.com/ip-address-ranges-by-country` and try manually plugging in ip adresses in place of `$addr` and check the output flag.