### PR TITLE
Add xdg-terminal-exec script to launch "$TERMINAL" for .desktop files

### DIFF
--- a/.local/bin/xdg-terminal-exec
+++ b/.local/bin/xdg-terminal-exec
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"$TERMINAL" -e "$@"


### PR DESCRIPTION
Solves an issue where terminal wouldn't get launched when opening
an application that has `Terminal=true` in its `.desktop` file.

https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2839

This works with GLib `2.76.0` and newer (released a month ago).

This is not a "proper" implementation of `xdg-terminal-exec`, but that
would require having to look for `.desktop` files of terminals and other
unnecessary stuff. This does the job and works for most terminals.