### PR TITLE
Fix sb-volume decimal integer misinterpreting

### DIFF
--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -30,9 +30,9 @@ split() {
 vol="$(printf "%.0f" "$(split "$vol" ".")")"
 
 case 1 in
-	$((vol >= 70)) ) icon="🔊" ;;
-	$((vol >= 30)) ) icon="🔉" ;;
-	$((vol >= 1)) ) icon="🔈" ;;
+	$((10#$vol >= 70)) ) icon="🔊" ;;
+	$((10#$vol >= 30)) ) icon="🔉" ;;
+	$((10#$vol >= 1)) ) icon="🔈" ;;
 	* ) echo 🔇 && exit ;;
 esac
 


### PR DESCRIPTION
Shell script interprets zero-prefixed decimal integer as octal integer so it throws an error when "vol" is equal to "08" or  "09" because this values are invalid octal numbers. Now "vol" forced to be decimal.