### PR TITLE
An Extremely Simple and Efficient Script I Think You All Like

### DIFF
--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,6 +1,6 @@
 #!/bin/dash
 
-command -v locate >/dev/null || {
+command -v locate dash >/dev/null || {
     sudo pacman -S mlocate &&
     notify-send "Locate not found. Installing..." || {
         notify-send "Failed. Run the script once on terminal OR change sudo permissions."
@@ -11,7 +11,7 @@ command -v locate >/dev/null || {
 [ -s "$HOME/.config/.mymlocate.db" ] || {
     notify-send "You have no database. Creating it..."
     disk_path=$(echo "" | dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
-    doas updatedb -o ~/.config/.mymlocate.db -U "$disk_path" || {
+    sudo updatedb -o ~/.config/.mymlocate.db -U "$disk_path" || {
         notify-send "Failed. Run the script once on terminal OR change doas permissions."
         exit 1
     }

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -10,7 +10,7 @@ command -v locate >/dev/null || {
 
 [ -s "$HOME/.config/.mymlocate.db" ] || {
     notify-send "You have no database. Creating it..."
-    disk_path=$(echo "" | rofi -dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
+    disk_path=$(echo "" | dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
     doas updatedb -o ~/.config/.mymlocate.db -U "$disk_path" || {
         notify-send "Failed. Run the script once on terminal OR change doas permissions."
         exit 1
@@ -18,5 +18,5 @@ command -v locate >/dev/null || {
 }
 
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
-chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | rofi -dmenu -p "Select Video")
+chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -i -l 10 -p "Select Video")
 mpv "$(echo "$video_files" | grep -F "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,10 +1,4 @@
 #!/bin/sh
-
-tempfile=$(mktemp)
-locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$' > "$tempfile"
-
-chosen_name=$(sed 's|.*/||; s/\.[^.]*$//' "$tempfile" | dmenu -i -l 10 -p "Select a video file:")
-chosen_path=$(grep "/$chosen_name\." "$tempfile")
-
-mpv "$chosen_path"
-rm -f "$tempfile"
+video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
+chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -p "Select Video")
+mpv "$(echo "$video_files" | grep "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+temp_file=$(mktemp)
+locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\wmv\|flv\|avi\)$' | awk -F/ '{name=$NF; gsub(/\.(mp4|mkv|webm|mov|m4v|wmv|flv|avi)$/, "", name); print name "\t" $0}' > "$temp_file"
+chosen_file_name_and_path=$(cut -f1 "$temp_file" | dmenu -i -l 10 -p "Select a video file:")
+mpv "$(awk -F'\t' -v chosen="$chosen_file_name_and_path" '$1 == chosen {print $2; exit}' "$temp_file")" && rm "$temp_file"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,4 +1,22 @@
-#!/bin/sh
+#!/bin/dash
+
+command -v locate >/dev/null || {
+    sudo pacman -S mlocate &&
+    notify-send "Locate not found. Installing..." || {
+        notify-send "Failed. Run the script once on terminal OR change sudo permissions."
+        exit 1
+    }
+}
+
+[ -s "$HOME/.config/.mymlocate.db" ] || {
+    notify-send "You have no database. Creating it..."
+    disk_path=$(echo "" | rofi -dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
+    doas updatedb -o ~/.config/.mymlocate.db -U "$disk_path" || {
+        notify-send "Failed. Run the script once on terminal OR change doas permissions."
+        exit 1
+    }
+}
+
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
-chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -i -l 10 -p "Select Video")
+chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | rofi -dmenu -p "Select Video")
 mpv "$(echo "$video_files" | grep -F "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,16 +1,16 @@
-#!/bin/dash
+#!/bin/sh
 
-command -v locate dash >/dev/null || {
-    sudo pacman -S mlocate &&
-    notify-send "Locate not found. Installing..." || {
-        notify-send "Failed. Run the script once on terminal OR change sudo permissions."
-        exit 1
-    }
+command -v locate >/dev/null || {
+    notify-send "Locate not found. Installing..."
+    sudo pacman -S mlocate 
+} || {
+    notify-send "Failed. Run the script once on terminal OR change sudo permissions."
+    exit 1
 }
 
 [ -s "$HOME/.config/.mymlocate.db" ] || {
     notify-send "You have no database. Creating it..."
-    disk_path=$(echo "" | dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
+    disk_path=$(echo "" | rofi -dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
     sudo updatedb -o ~/.config/.mymlocate.db -U "$disk_path" || {
         notify-send "Failed. Run the script once on terminal OR change doas permissions."
         exit 1
@@ -18,5 +18,5 @@ command -v locate dash >/dev/null || {
 }
 
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
-chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -i -l 10 -p "Select Video")
+chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | rofi -dmenu -p "Select Video")
 mpv "$(echo "$video_files" | grep -F "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,4 +1,4 @@
 #!/bin/sh
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
 chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -p "Select Video")
-mpv "$(echo "$video_files" | grep "/$chosen_file.")"
+mpv "$(echo "$video_files" | fgrep "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,4 +1,4 @@
 #!/bin/sh
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
-chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -l 10 -p "Select Video")
+chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -i -l 10 -p "Select Video")
 mpv "$(echo "$video_files" | grep -F "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -12,7 +12,7 @@ command -v locate >/dev/null || {
     notify-send "You have no database. Creating it..."
     disk_path=$(echo "" | rofi -dmenu -l 0 -p "Enter the disk path (e.g '/mnt/harddisk'): ")
     sudo updatedb -o ~/.config/.mymlocate.db -U "$disk_path" || {
-        notify-send "Failed. Run the script once on terminal OR change doas permissions."
+        notify-send "Failed. Run the script once on terminal OR change sudo permissions."
         exit 1
     }
 }

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,4 +1,4 @@
 #!/bin/sh
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
 chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -p "Select Video")
-mpv "$(echo "$video_files" | fgrep "/$chosen_file.")"
+mpv "$(echo "$video_files" | grep -F "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,4 +1,4 @@
 #!/bin/sh
 video_files=$(locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$')
-chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -p "Select Video")
+chosen_file=$(echo "$video_files" | sed 's|.*/||; s/\.[^.]*$//' | dmenu -l 10 -p "Select Video")
 mpv "$(echo "$video_files" | grep -F "/$chosen_file.")"

--- a/.local/bin/videosearch
+++ b/.local/bin/videosearch
@@ -1,6 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-temp_file=$(mktemp)
-locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\wmv\|flv\|avi\)$' | awk -F/ '{name=$NF; gsub(/\.(mp4|mkv|webm|mov|m4v|wmv|flv|avi)$/, "", name); print name "\t" $0}' > "$temp_file"
-chosen_file_name_and_path=$(cut -f1 "$temp_file" | dmenu -i -l 10 -p "Select a video file:")
-mpv "$(awk -F'\t' -v chosen="$chosen_file_name_and_path" '$1 == chosen {print $2; exit}' "$temp_file")" && rm "$temp_file"
+tempfile=$(mktemp)
+locate -d ~/.config/.mymlocate.db -b -r '.*\.\(mp4\|mkv\|webm\|mov\|m4v\|wmv\|flv\|avi\)$' > "$tempfile"
+
+chosen_name=$(sed 's|.*/||; s/\.[^.]*$//' "$tempfile" | dmenu -i -l 10 -p "Select a video file:")
+chosen_path=$(grep "/$chosen_name\." "$tempfile")
+
+mpv "$chosen_path"
+rm -f "$tempfile"


### PR DESCRIPTION
EDIT: Superseded by #1419 

The inspiration: (Luke Smith's Video): [**"Unix Chad JUST WON'T STOP Piping!"**](https://youtu.be/w_37upFE-qw) 

**Execution Time**: **0.0 seconds** on my system with more than **10.000** video files.

Very Short Summary: 
- This script feeds the "dmenu" with a list of all videos in a hard drive. 
- **File paths and extensions are removed** for better readability for the dmenu list. 
- Opens the chosen video file in "mpv" using the complete paths and extensions. 
- An approach of having the least amount of lines & characters while keeping the simplicity and performance has been used.

`The actual script is actually a 3 line script but I added some error handling to increase convenience. You can delete everything but the last 3 lines if you want.`

The first 20 lines of the script checks if related programs installed, and check if you have a video database for locate command. If not it does everything for you and notifies you appropriately. If you can't run sudo commands without entering your password, then it will also notify you about it regarding that you need to run the script on terminal or change your permissions.

### Detailed Explanation for Everyone:

**locate** command is for locating all of the video files with their given extensions:
**-d ~/.config/.mymlocate.db**: Specifies the path to the database to use.
**-b**: Matches only the name of the files (no directory names).
**-r ...** : Uses a regular expression to match filenames. Specifically, it's matching files that end with the given extensions.
**> "$tempfile"**: This redirects the output (the matched file paths) of the locate command to the temporary file we created earlier.

**chosen_name=$(sed 's|.*/||; s/\.[^.]*$//' "$tempfile" | dmenu -p "Select Video")**:
**'s|.*/||'** This sed expression (details below) removes the directory part of each file path, leaving just the base filename.
**s/\.[^.]*$//** This sed expression removes the file extension from the base filename.

**chosen_path=$(fgrep "/$chosen_name\." : The pattern to search for. It looks for lines that contain our chosen filename followed by a period, ensuring we match the correct file. fgrep is faster than grep because it doesn't have regex processor. It's also safer so you can open file names with regex characters.

Finally we use the chosen path with mpv.

### Regular Expressions

We combine two sed substitution commands into one command by separating them with **;**

We use this scheme here: **'s|pattern|replacement|; s|pattern|replacement|'**

**'s|.*/||'**

**s** Stands for "substitute".

**|** This is an alternative delimiter used for the substitution operation. Traditionally, the **/** character is used as the delimiter, but in this case, **|** has been chosen likely to avoid having to escape the **/** character in the pattern, making it more readable.

**Pattern: .*/**

**.*** This matches any character (represented by .) zero or more times (represented by *).

**/** This matches a forward slash. Since we use **|** for the separator we don't have to escape the slash.

So, **.*/** matches everything up to the last **/** in a string.

For example, for the string **/home/user/videos/movie.mp4**, the pattern **.*/** matches **/home/user/videos/**

Replacement: **||**

There's nothing between the two **|** delimiters, which means it's an empty string.

This command will replace everything up to and including the last **/** with nothing (it'll remove that part), effectively extracting just the base filename from a full path.

**'s/\.[^.]*$//'** 

We use traditional scheme here **s/pattern/replacement/**

**s** As before, this is the "substitute" command.

**/** This time, the traditional **/** delimiter is used.

**\.[^.]*$**

**\.** Matches a literal dot (.). The dot is prefixed with a backslash to escape it, since a dot has special meaning in regex (it matches any character).

**[^.]** The square brackets denote a character class. The **^** at the beginning of this class negates the character class, meaning it will match any character that is not a dot.

**\*** Matches the preceding pattern (in this case, the negated character class) zero or more times.

**$** Matches the end of the line.

This pattern matches the last dot and everything after it (up to the end of the line) that doesn't contain another dot. It's designed to match file extensions.

For example, in the filename movie.part1.mp4, the pattern will match .mp4.

**Replacement: //**

Again, there's nothing between the two **/** delimiters, so this part will be replaced with nothing.

This command will remove the last file extension from a filename.

When you run both commands in sequence using the semicolon to separate them, you're effectively:

Removing the path, leaving only the base filename.
Removing the file extension from that filename.

For the string **/home/user/videos/movie.part1.mp4**, after both **sed** operations, you'll be left with **movie.part1**