### PR TITLE
Improved Bookmark Script (Simplicity + Convenience)

### DIFF
--- a/.local/bin/bookmarkthis
+++ b/.local/bin/bookmarkthis
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+FILE="~/.local/share/larbs/urlquery"
+
+URL_FROM_CLIPBOARD=$(xclip -o)
+
+if echo "$URL_FROM_CLIPBOARD" | grep -q "^http"; then
+    URL_ALREADY_EXISTS=$(jq --arg url "$URL_FROM_CLIPBOARD" 'map(.[1] == $url) | any' "$FILE")
+
+    if [ "$URL_ALREADY_EXISTS" = "true" ]; then
+        notify-send "The URL is already in the list."
+        exit 1
+    fi
+
+    URL_NAME=$(dmenu -l 0 -p "Enter a name for the URL")
+
+    if [ -n "$URL_NAME" ]; then
+        jq --arg name "$URL_NAME" --arg url "$URL_FROM_CLIPBOARD" '. += [[$name, $url]]' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE" &&
+	notify-send "$URL_NAME is bookmarked."
+    fi
+else
+    notify-send "The clipboard content is not a valid URL."
+fi


### PR DESCRIPTION
This script allows us to bookmark websites as names instead of URLs.

**Execution Time:** Instant
Required File: ~/.local/share/larbs/urlquery as it can be seen below (the entries can change of course). 
**Required Programs: jq** | grep | dmenu | echo | dunst

It is useful with the other script: "bookmarksearch" that helps us use search engines on dmenu or directly open the site if the URL doesn't include "search" word in it.

In this case the first entry would give us a second dmenu prompt to enter a keyword and the second entry will be opened directly when chosen:
 ```
[  
  [
    "searxng",
    "https://www.paulgo.io/search?q="
  ],
  [
    "cooking",
    "https://based.cooking"
  ]
]
```

The script take the formatting and duplicate URLs into account. You don't need to worry about it.

**Detailed Explanation:**
- We use a text file to store the URLs in: "~/.local/share/larbs/urlquery"
- The script uses the command "jq" to see a JSON data with specific information. We can use it to get the complete URL address or the name of the website.
- "grep" checks if the selected entry starts with "http". If it does, the script adds that URL with specific formatting inside the urlquery file after asking what should the URL be named.
- "jq" command again, considers the format of the file and adds a comma at the end followed by a new urlquery name and the address inside brackets and quotes in order to keep formatting correct. 
- notify-send informs us about the output: If the URL is already on the list, or the selected entry is not an URL or when it is added successfully.