### PR TITLE
Improved Bookmarks (Separate URL and Name + Search with Keywords)

### DIFF
--- a/.local/bin/bookmarksearch
+++ b/.local/bin/bookmarksearch
@@ -2,6 +2,8 @@
 
 FILE="~/.local/share/larbs/urlquery"
 
+OBJ_SELECTED=$(jq -r ".[][0]" "$FILE" | rofi -dmenu -l 10 -p "Select a website")
+
 ENTRY_EXISTS=$(jq -r --arg sel "$OBJ_SELECTED" 'map(.[0] == $sel) | any' "$FILE")
 
 if [ -z "$OBJ_SELECTED" ] || ([ "$ENTRY_EXISTS" = "false" ] && [ "$OBJ_SELECTED" != "@@" ]); then

--- a/.local/bin/bookmarksearch
+++ b/.local/bin/bookmarksearch
@@ -2,6 +2,8 @@
 
 FILE="~/.local/share/larbs/urlquery"
 
+[ -s "$FILE" ] || echo "[]" > "$FILE"
+
 OBJ_SELECTED=$(jq -r ".[][0]" "$FILE" | rofi -dmenu -l 10 -p "Select a website")
 
 ENTRY_EXISTS=$(jq -r --arg sel "$OBJ_SELECTED" 'map(.[0] == $sel) | any' "$FILE")

--- a/.local/bin/bookmarksearch
+++ b/.local/bin/bookmarksearch
@@ -4,15 +4,37 @@ FILE="~/.local/share/larbs/urlquery"
 
 OBJ_SELECTED=$(jq -r ".[][0]" "$FILE" | dmenu -l 10 -p "Select a website")
 
-if [ -z "$OBJ_SELECTED" ]; then
-    exit 1
-fi
+add_new_bookmark() {
+    URL_FROM_CLIPBOARD=$(xclip-o)
 
-URLQUERY=$(jq -r --arg sel "$OBJ_SELECTED" 'map(select(.[0] == $sel))[0][1]' "$FILE")
+    if echo "$URL_FROM_CLIPBOARD" | grep -q "^http"; then
+        URL_ALREADY_EXISTS=$(jq --arg url "$URL_FROM_CLIPBOARD" 'map(.[1] == $url) | any' "$FILE")
 
-if echo "$URLQUERY" | grep -q "search"; then
-    OBJ_KEYWORDS=$(dmenu -l 0 -p "Enter keywords" | tr " " "+")
-    firefox "${URLQUERY}${OBJ_KEYWORDS}"
+        if [ "$URL_ALREADY_EXISTS" = "true" ]; then
+            notify-send "The URL is already in the list."
+            exit 1
+        fi
+
+        URL_NAME=$(dmenu -l 0 -p "Enter a name for the URL")
+
+        if [ -n "$URL_NAME" ]; then
+            jq --arg name "$URL_NAME" --arg url "$URL_FROM_CLIPBOARD" '. += [[$name, $url]]' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE" &&
+	    notify-send "$URL_NAME is bookmarked"
+        fi
+    else
+        notify-send "The clipboard content is not a valid URL."
+    fi
+}
+
+if [ "$OBJ_SELECTED" = "@@" ]; then
+    add_new_bookmark
 else
-    firefox "${URLQUERY}"
+    URLQUERY=$(jq -r --arg sel "$OBJ_SELECTED" 'map(select(.[0] == $sel))[0][1]' "$FILE")
+
+    if echo "$URLQUERY" | grep -q "search"; then
+        OBJ_KEYWORDS=$(dmenu -l 0 -p "Enter keywords" | tr " " "+")
+        firefox "${URLQUERY}${OBJ_KEYWORDS}"
+    else
+        firefox "${URLQUERY}"
+    fi
 fi

--- a/.local/bin/bookmarksearch
+++ b/.local/bin/bookmarksearch
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+FILE="~/.local/share/larbs/urlquery"
+
+OBJ_SELECTED=$(jq -r ".[][0]" "$FILE" | dmenu -l 10 -p "Select a website")
+
+if [ -z "$OBJ_SELECTED" ]; then
+    exit 1
+fi
+
+URLQUERY=$(jq -r --arg sel "$OBJ_SELECTED" 'map(select(.[0] == $sel))[0][1]' "$FILE")
+
+if echo "$URLQUERY" | grep -q "search"; then
+    OBJ_KEYWORDS=$(dmenu -l 0 -p "Enter keywords" | tr " " "+")
+    firefox "${URLQUERY}${OBJ_KEYWORDS}"
+else
+    firefox "${URLQUERY}"
+fi

--- a/.local/bin/bookmarksearch
+++ b/.local/bin/bookmarksearch
@@ -2,15 +2,9 @@
 
 FILE="~/.local/share/larbs/urlquery"
 
-OBJ_SELECTED=$(jq -r ".[][0]" "$FILE" | dmenu -l 10 -p "Select a website")
-
-if [ -z "$OBJ_SELECTED" ]; then
-    exit 0
-fi
-
 ENTRY_EXISTS=$(jq -r --arg sel "$OBJ_SELECTED" 'map(.[0] == $sel) | any' "$FILE")
 
-if [ "$ENTRY_EXISTS" = "false" ] && [ "$OBJ_SELECTED" != "@@" ]; then
+if [ -z "$OBJ_SELECTED" ] || ([ "$ENTRY_EXISTS" = "false" ] && [ "$OBJ_SELECTED" != "@@" ]); then
     exit 0
 fi
 

--- a/.local/bin/bookmarksearch
+++ b/.local/bin/bookmarksearch
@@ -4,6 +4,16 @@ FILE="~/.local/share/larbs/urlquery"
 
 OBJ_SELECTED=$(jq -r ".[][0]" "$FILE" | dmenu -l 10 -p "Select a website")
 
+if [ -z "$OBJ_SELECTED" ]; then
+    exit 0
+fi
+
+ENTRY_EXISTS=$(jq -r --arg sel "$OBJ_SELECTED" 'map(.[0] == $sel) | any' "$FILE")
+
+if [ "$ENTRY_EXISTS" = "false" ] && [ "$OBJ_SELECTED" != "@@" ]; then
+    exit 0
+fi
+
 add_new_bookmark() {
     URL_FROM_CLIPBOARD=$(xclip-o)
 


### PR DESCRIPTION
The inspiration: (Luke Smith's Video): ["Bookmarking for Unix Chads"](https://youtu.be/d_11QaTlf1I)

**Execution Time:** Instant
**Required Programs: jq** | echo | grep | dunst | browser
**Instructions at the Bottom for the First Run**

**Video Example for the Script in 45 Seconds:**

https://user-images.githubusercontent.com/89175311/233820987-fc35fbb6-e9e2-4b6f-ae4f-8e464deaea12.mp4



This script allows us to open a bookmarked URL on the browser, only showing the name of the website, stripping the URL from the dmenu list.
- If the URL has the word "search" in it, then the script will offer for a second dmenu for you to enter a keyword to search.
- "searxng" entry, will offer for a second input after being chosen. Then you can enter a keyword to search from that website. It can be any website with a search function. So look at your bookmarks --> choose "searxng" entry --> Write a keyword and enter --> Search for that keyword on searxng.
- Otherwise it will open the website directly --> "cooking" entry can open "https://based.cooking" for example.
- We rely on the JSON data formatting to separate URLs from the names we put on websites. So we need the program "jq".
- File creation and renaming in the script are for data integrity and preventing data corruption. If you don't want doing that, modify the script with:
`jq -i --arg name "$URL_NAME" --arg url "$URL_FROM_CLIPBOARD" '. += [[$name, $url]]' "$FILE"`

Summary: It first selects a website using dmenu, then checks if "search" is present in the URLQUERY such as "https://paulgo.io/**search**?q=". If "search" is present, it asks for keywords before opening the URL. If not, it directly opens the URL without asking for keywords.

**Detailed Explanation:**
- We had a urlquery file inside ~/.local/share/larbs/urlquery. In that file we have the names of the websites such as "cooking" and next to them, we also have the URL of those websites: "https://based.cooking".
- The program "jq" will match those entries, then show us the first entry on the list and that is the name of the website. This is similar to "awk" command. But doing this with awk is either impossible or very inconvenient or less efficient. If one of the website names selected, then the script uses the second entry that is the complete URL address. We don't need that address but the browser does.
- Grep checks if the URL has search in it. If it does, it prompts us with a newer dmenu for keyword inputs such as "shop for food". If it does not, the URL is opened without a second prompt.

- If you type @@ inside the dmenu prompt then you will add the website you highlighted as a bookmark if not already present. Before being added, you will get a prompt about how you name that certain URL. For Wayland users, **xclip-o** can be changed with **wl-paste**. You should copy the URL in this case though.

**Instructions for the First Run:**

Install jq at first: `pacman -S jq` or `emerge jq` for Arch and Gentoo respectively.
You can change the browser inside the script. Change firefox with whatever you want. $BROWSER should work too.

1. Select (highlight) a URL starting with http.
2. Then run this script.
3. Type @@ inside dmenu prompt and enter. (This can of course be changed if you don't like @@)
4. You will see a prompt wanting you to name that URL. Name whatever you want and enter. 
5. Now you have successfully created the file and your first bookmark in it: `~/.local/share/larbs/urlquery`.
The file will look like below but you don't need to worry about its formatting. The script handles that. You can manually change it though, it's dead simple:
```
[
  [
    "searxng",
    "https://paulgo.io/search?q="
  ],
  [
    "cooking",
    "https://based.cooking/"
  ]
]
```

