### PR TITLE
Update volume module on headphone (dis)connect

### DIFF
--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -7,7 +7,7 @@ xrandr --dpi 96		# Set DPI. User may want to use a larger number for larger scre
 setbg &			# set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources & xrdbpid=$!	# Uncomment to use Xresources colors/settings on startup
 
-autostart="mpd xcompmgr dunst unclutter pipewire remapd"
+autostart="mpd xcompmgr dunst unclutter pipewire remapd volumed"
 
 for program in $autostart; do
 	pidof -sx "$program" || "$program" &

--- a/.local/bin/volumed
+++ b/.local/bin/volumed
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Update the volume module in the statusbar whenever
+# headphones are added or removed.
+
+while :; do
+	grep -qP -m1 '^jack\/headphone' <(acpi_listen)
+	pkill -RTMIN+10 "${STATUSBAR:-dwmblocks}"
+done


### PR DESCRIPTION
fixes #1304 

Requires a new application in progs.csv, `acpid`. There is a problem of how to enable this daemon to start on boot from install, especially considering that on artix, this application also has its own -runit, -6, etc. packages (maybe there's a different package or way of doing this better?)

Another issue of volumed is that it depends on a hardcoded signal for dwmblocks which can't be passed as its ran from xprofile, but seeing that other scripts like transadd also use a hardcoded signal, I think it is alright.

If anyone finds any better way of listening to acpi messages, please give a comment. 