### PR TITLE
Make sure sb-volume module is updated after closing pulsemixer

### DIFF
--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -3,7 +3,7 @@
 # Prints the current volume or 🔇 if muted.
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e pulsemixer ;;
+	1) setsid -w -f "$TERMINAL" -e pulsemixer; pkill -RTMIN+10 "${STATUSBAR:-dwmblocks}" ;;
 	2) wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle ;;
 	4) wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%+ ;;
 	5) wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%- ;;


### PR DESCRIPTION
Mirrors what also happens when the user opens pulsemixer with Super+F4. 

Normally when the user opens pulsemixer with Super+F4, makes changes and closes it again, `sb-volume` gets updated. This makes it also happen when the module is left mouse clicked, as it currently doesn't update.