### PR TITLE
Fix unsupported characters in vim-airline

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -67,6 +67,14 @@ set noshowcmd
 	nm <leader>i :call ToggleIPA()<CR>
 	imap <leader>i <esc>:call ToggleIPA()<CR>a
 	nm <leader>q :call ToggleProse()<CR>
+	
+" vim-airline
+	if !exists('g:airline_symbols')
+  	    let g:airline_symbols = {}
+	endif
+	let g:airline_symbols.colnr = ' C:'
+	let g:airline_symbols.linenr = ' L:'
+	let g:airline_symbols.maxlinenr = '☰ '
 
 " Shortcutting split navigation, saving a keypress:
 	map <C-h> <C-w>h


### PR DESCRIPTION
Here's how the bar is supposed to look, with a special symbol for the line number and the column number, which currently doesn't render because of missing fonts:

![supposed](https://user-images.githubusercontent.com/108810900/235290232-75dae7bd-8678-4d34-a98d-ef78ab6293c2.png)

This is how the bar currently looks :

![before](https://user-images.githubusercontent.com/108810900/235290391-96b884df-0d95-4311-9610-70a7911a3036.png)

I replaced the missing symbols with letters, and this is how it looks after this PR:

![after](https://user-images.githubusercontent.com/108810900/235290652-bc5ecb00-f81a-4cab-b996-20027c53091f.png)
