### PR TITLE
dwmblocks update on song change

### DIFF
--- a/.config/ncmpcpp/config
+++ b/.config/ncmpcpp/config
@@ -30,3 +30,4 @@ progressbar_color = black:b
 progressbar_elapsed_color = blue:b
 statusbar_color = red
 statusbar_time_color = cyan:b
+execute_on_song_change="pkill -RTMIN+11 dwmblocks"


### PR DESCRIPTION
Songs were not updating immediately in dwmblocks after song change. Added the ability for sb-music to update after a song change