### PR TITLE
change requested by lf-git after update.

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -24,7 +24,7 @@ set period 1
 set hiddenfiles ".*:*.aux:*.log:*.bbl:*.bcf:*.blg:*.run.xml"
 set cleaner '~/.config/lf/cleaner'
 set previewer '~/.config/lf/scope'
-set autoquit on
+set autoquit true
 
 # cmds/functions
 cmd open ${{


### PR DESCRIPTION
It seems something is changed in how lf handles bools in lfrc. This change works for me and stops the warning.