### PR TITLE
sb-forecast: don't wrap horizontally on short terminal

### DIFF
--- a/.local/bin/statusbar/sb-forecast
+++ b/.local/bin/statusbar/sb-forecast
@@ -38,7 +38,7 @@ showweather() {
 }
 
 case $BLOCK_BUTTON in
-	1) setsid -f "$TERMINAL" -e less -Srf "$weatherreport" ;;
+	1) setsid -f "$TERMINAL" -e less -Sf "$weatherreport" ;;
 	2) getforecast && showweather ;;
 	3) notify-send "🌈 Weather module" "\- Left click for full forecast.
 - Middle click to update forecast.


### PR DESCRIPTION
Small PR, fixes the issue that sb-forecast wraps when the terminal is too small horizontally, now it neatly allows you to scroll