### PR TITLE
weath: Add option to get forecast from a different location

### DIFF
--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -20,7 +20,7 @@ se() {
 
 weath() {
 	[ -z "$1" ] && less -S ${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport ||
-		curl --retry 5 -sm 10 "${WTTRURL:-wttr.in}/$1" | less -S
+		curl -sm 5 "${WTTRURL:-wttr.in}/$1" | less -S
 	;}
 
 # Verbosity and settings that you pretty much just always are going to want.

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -16,12 +16,26 @@ done; unset command
 se() {
 	choice="$(find ~/.local/bin -mindepth 1 -printf '%P\n' | fzf)"
 	[ -f "$HOME/.local/bin/$choice" ] && $EDITOR "$HOME/.local/bin/$choice"
-	;}
+	}
 
 weath() {
-	[ -z "$1" ] && less -S ${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport ||
-		curl -sm 5 "${WTTRURL:-wttr.in}/$1" | less -S
-	;}
+	if [ "$1" = 'cp' ]; then
+		[ -z "$2" ] && sed 's/\x1b\[[^m]*m//g' "${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport" | xclip -selection clipboard &&
+			notify-send "Weather forecast for '$LOCATION' copied to clipboard." ||
+				{ data="$(curl -sfm 5 "${WTTRURL:-wttr.in}/$2?T")" &&
+				notify-send "Weather forecast for '$2' copied to clipboard." &&
+				echo "$data" | xclip -selection clipboard ||
+				notify-send 'Failed to get weather forecast!' 'Check your internet connection and if the location is correct.'; }
+	else
+		[ -n "$2" ] &&
+			notify-send "Invalid option '$1'! The only valid option is 'cp'." &&
+			return 1
+
+		[ -z "$1" ] && less -S "${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport" ||
+			data="$(curl -sfm 5 "${WTTRURL:-wttr.in}/$1")" && echo "$data" | less -S ||
+				notify-send 'Failed to get weather forecast!' 'Check your internet connection and if the location is correct.'
+	fi
+	}
 
 # Verbosity and settings that you pretty much just always are going to want.
 alias \

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -18,25 +18,6 @@ se() {
 	[ -f "$HOME/.local/bin/$choice" ] && $EDITOR "$HOME/.local/bin/$choice"
 	}
 
-weath() {
-	if [ "$1" = 'cp' ]; then
-		[ -z "$2" ] && sed 's/\x1b\[[^m]*m//g' "${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport" | xclip -selection clipboard &&
-			notify-send "Weather forecast for '$LOCATION' copied to clipboard." ||
-				{ data="$(curl -sfm 5 "${WTTRURL:-wttr.in}/$2?T")" &&
-				notify-send "Weather forecast for '$2' copied to clipboard." &&
-				echo "$data" | xclip -selection clipboard ||
-				notify-send 'Failed to get weather forecast!' 'Check your internet connection and if the location is correct.'; }
-	else
-		[ -n "$2" ] &&
-			notify-send "Invalid option '$1'! The only valid option is 'cp'." &&
-			return 1
-
-		[ -z "$1" ] && less -S "${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport" ||
-			data="$(curl -sfm 5 "${WTTRURL:-wttr.in}/$1")" && echo "$data" | less -S ||
-				notify-send 'Failed to get weather forecast!' 'Check your internet connection and if the location is correct.'
-	fi
-	}
-
 # Verbosity and settings that you pretty much just always are going to want.
 alias \
 	cp="cp -iv" \

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -18,6 +18,11 @@ se() {
 	[ -f "$HOME/.local/bin/$choice" ] && $EDITOR "$HOME/.local/bin/$choice"
 	;}
 
+weath() {
+	[ -z "$1" ] && less -S ${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport ||
+		curl --retry 5 -sm 10 "${WTTRURL:-wttr.in}/$1" | less -S
+	;}
+
 # Verbosity and settings that you pretty much just always are going to want.
 alias \
 	cp="cp -iv" \
@@ -58,4 +63,3 @@ alias \
 	lf="lfub" \
 	magit="nvim -c MagitOnly" \
 	ref="shortcuts >/dev/null; source ${XDG_CONFIG_HOME:-$HOME/.config}/shell/shortcutrc ; source ${XDG_CONFIG_HOME:-$HOME/.config}/shell/zshnameddirrc" \
-	weath="less -S ${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport" \

--- a/.local/bin/weath
+++ b/.local/bin/weath
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Get the weather on the terminal. You can pass an alternative location as a parameter,
+# and/or use the 'cp' option to copy the forecast as plaintext to the clipboard.
+
+report="${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport"
+
+if [ "$1" = 'cp' ]; then
+        # shellcheck disable=SC2015
+        [ -z "$2" ] && sed 's/\x1b\[[^m]*m//g' "$report" | xclip -selection clipboard &&
+                notify-send "Weather forecast for '${LOCATION:-$(head -n 1 "$report" | cut -d' ' -f3-)}' copied to clipboard." ||
+                        { data="$(curl -sfm 5 "${WTTRURL:-wttr.in}/$2?T")" &&
+                        notify-send "Weather forecast for '$2' copied to clipboard." &&
+                        echo "$data" | xclip -selection clipboard ||
+                        notify-send 'Failed to get weather forecast!' 'Check your internet connection and the supplied location.'; }
+else
+        [ -n "$2" ] &&
+                notify-send "Invalid option '$1'! The only valid option is 'cp'." &&
+                exit 1
+
+        # shellcheck disable=SC2015
+        [ -z "$1" ] && less -S "$report" ||
+                data="$(curl -sfm 5 "${WTTRURL:-wttr.in}/$1")" && echo "$data" | less -S ||
+                        notify-send 'Failed to get weather forecast!' 'Check your internet connection and the supplied location.'
+fi


### PR DESCRIPTION
You can now add the forecast location as a parameter to weath, very useful if you want to quickly know what the weather is like somewhere else. Had to use a function because aliases don't support command line parameters.

`weath`
`weath 'Rome'`

Also added the 'cp' option so you can copy the forecast as plaintext to your clipboard, so that it can be shared. I've found myself using screenshots for it before, but that's impractical.

`weath cp`
`weath cp 'Rome'`