### PR TITLE
Fix rename key bindings in lf

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -113,11 +113,11 @@ map X !$f
 map o &mimeopen "$f"
 map O $mimeopen --ask "$f"
 
-map A rename # at the very end
+map A :rename; cmd-end # at the very end
 map c push A<c-u> # new rename
-map I push A<c-a> # at the very beginning
-map i push A<a-b><a-b><a-f> # before extension
-map a push A<a-b> # after extension
+map I :rename; cmd-home # at the very beginning
+map i :rename # before extension
+map a :rename; cmd-right # after extension
 map B bulkrename
 map b $setbg $f
 


### PR DESCRIPTION
As mentioned in https://github.com/gokcehan/lf/pull/1162, lf now defaults to  place the cursor at the dot if there is an extension, which breaks most of the current rename key bindings. This PR fixes that.