### PR TITLE
Re-add whitespace to some buffer types as needed.

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -117,6 +117,8 @@ set noshowcmd
  	autocmd BufWritePre * let currPos = getpos(".")
 	autocmd BufWritePre * %s/\s\+$//e
 	autocmd BufWritePre * %s/\n\+\%$//e
+  autocmd BufWritePre *.[ch] %s/\%$/\r/e " add trailing newline for ANSI C standard
+  autocmd BufWritePre *neomutt* %s/^--$/-- /e " dash-dash-space signature delimiter in emails
   	autocmd BufWritePre * cal cursor(currPos[1], currPos[2])
 
 " When shortcut files are updated, renew bash and ranger configs with new material:


### PR DESCRIPTION
Very arcane.

C ANSI standard requires a newline at the end. GCC will complain.[1]

Email signatures should have a space after the -- according to the standard. Neomutt does this automatically for you if you have a signature.[2]

[1]: It's in the ANSI standard pdf somewhere. Can't be bothered to find it right now. Think it is in c99 too.
[2]: https://en.wikipedia.org/wiki/Signature_block#Standard_delimiter
