### PR TITLE
none of the encrypted devices are listed if no drives are decrypted a…

### DIFF
--- a/.local/bin/mounter
+++ b/.local/bin/mounter
@@ -36,7 +36,7 @@ filter() { sed "s/ /:/g" | awk -F':' '$7==""{printf "%s%s (%s) %s\n",$1,$3,$5,$6
 unopenedluks="$(for drive in $allluks; do
 	uuid="${drive%% *}"
 	uuid="${uuid//-}"	# This is a bashism.
-	for open in $decrypted; do
+	[ -n "$decrypted" ] && for open in $decrypted; do
 		[ "$uuid" = "$open" ] && break 1
 	done && continue 1
 	echo "🔒 $drive"


### PR DESCRIPTION
…lready

The part
```
for open in $decrypted; do
		[ "$uuid" = "$open" ] && break 1
done
```
exits with `0` if the variable `$decrypted` is empty, causing none of the encrypted devices to be put into the `$unopenedluks` variable. This commit fixes this problem.