### PR TITLE
Launch dwm in a dbus session

### DIFF
--- a/.config/x11/xinitrc
+++ b/.config/x11/xinitrc
@@ -14,4 +14,4 @@ else
 	. "$HOME/.xprofile"
 fi
 
-ssh-agent dwm
+exec dbus-launch --exit-with-session dwm

--- a/.config/x11/xinitrc
+++ b/.config/x11/xinitrc
@@ -13,5 +13,6 @@ if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/x11/xprofile" ]; then
 else
 	. "$HOME/.xprofile"
 fi
-
-exec dbus-launch --exit-with-session dwm
+# Activate dbus variables
+dbus-update-activation-environment --all
+ssh-agent dwm

--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -8,7 +8,6 @@ setbg &			# set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources & xrdbpid=$!	# Uncomment to use Xresources colors/settings on startup
 
 autostart="mpd xcompmgr dunst unclutter pipewire remapd"
-eval $(ssh-agent)
 
 for program in $autostart; do
 	pidof -sx "$program" || "$program" &

--- a/.config/x11/xprofile
+++ b/.config/x11/xprofile
@@ -8,6 +8,7 @@ setbg &			# set the background with the `setbg` script
 #xrdb ${XDG_CONFIG_HOME:-$HOME/.config}/x11/xresources & xrdbpid=$!	# Uncomment to use Xresources colors/settings on startup
 
 autostart="mpd xcompmgr dunst unclutter pipewire remapd"
+eval $(ssh-agent)
 
 for program in $autostart; do
 	pidof -sx "$program" || "$program" &


### PR DESCRIPTION
This makes it so programs can "talk" to each-other for example a problem that i ran into was with gnome-keyring not being able to be used in programs like in vscodium when getting my ssh keys

While the init system runs dbus, it is  only the system wide bus, not a session bus