### PR TITLE
remove 'rotdir' | simplify and improve directory rotation

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -34,13 +34,18 @@ cmd open ${{
         text/*|application/json|inode/x-empty|application/x-subrip) $EDITOR $fx;;
 	image/x-xcf) setsid -f gimp $f >/dev/null 2>&1 ;;
 	image/svg+xml) display -- $f ;;
-	image/*) rotdir $f | grep -i "\.\(png\|jpg\|jpeg\|gif\|webp\|avif\|tif\|ico\)\(_large\)*$" |
-		setsid -f sxiv -aio 2>/dev/null | while read -r file; do
-			[ -z "$file" ] && continue
-			lf -remote "send select \"$file\""
-			lf -remote "send toggle"
-		done &
-		;;
+	image/*) bash -c '
+            shopt -s nullglob
+            dir="$0"
+            selected_file="$1"
+            images=($(ls "$dir"/*.{jpg,jpeg,png,webp,bmp,tiff,tif,raw,ico,exif,heic,heif,gif,avif,jxl} | sort -V))
+	    for ((i=0; i<${#images[@]}; i++)); do
+                [[ "${images[i]}" = "$selected_file" ]] && {
+                    sxiv -abiof "${images[@]:i}" "${images[@]:0:i}"
+                    break
+                }
+            done
+        ' "$PWD" "$fx";;
 	audio/*|video/x-ms-asf) mpv --audio-display=no $f ;;
 	video/*) setsid -f mpv $f -quiet >/dev/null 2>&1 ;;
 	application/pdf|application/vnd.djvu|application/epub*) setsid -f zathura $fx >/dev/null 2>&1 ;;


### PR DESCRIPTION
This method reads image files directly from the current directory **$PWD** and then uses an array to keep track of all the images. The use of Bash built-in commands like for loop and if condition ensure a faster execution because there is no need to create a subprocess for each image file. The sxiv command is run only once when the selected image is found.

Furthermore, this method takes advantage of array slicing in Bash ("**${images[@]:i}" "${images[@]:0:i}**"). This feature allows the program to pass the images that come after the selected image (including the selected image) and before the selected image, to sxiv in correct order. This maintains the file order of the directory. The use of **sort -V** also contributes to maintaining the file order as it sorts version numbers within text.

In terms of efficiency, using Bash built-in operations with arrays should consume less system resources compared to lots of pipelines with multiple processes.

The old method uses the **rotdir** script which, when combined with **awk, ls, grep, setsid, and sxiv**, creates multiple subprocesses. This increases the overhead for context switching between these processes, leading to more system resource usage and a slower operation than the first method.

Moreover, the use of **setsid -f sxiv -aio 2>/dev/null** might launch sxiv multiple times, increasing the number of processes and resource usage.

In terms of file ordering, the rotdir script doesn't have explicit sorting. This might not necessarily match the desired order in some cases.

Lastly, the second method uses lf -remote to interact with the lf file manager. The command is run each time a new image is selected, adding an additional level of complexity and overhead to the process.

The first method is more readable and maintainable due to its use of simple Bash constructs. The logic is straightforward and doesn't involve external scripts.

On the other hand, the second method requires understanding the rotdir script, making it more complex to read and understand. The maintenance of this script would also need to be considered alongside the lfrc file, adding an extra layer of complexity.

We can even get rid of ls and sort by using bash globbing alone but then the files are ordered lexicographically, not numerically. Meaning they would go to 10th after 1st rather than 2nd. There could be a workaround though with naming the files with leading zeroes such as 01, 02 and so on.

# Detailed Explanation

**shopt -s nullglob**

This line tells bash to treat patterns which don't match any files (globs) as expanding to a null string, rather than themselves. This avoids problems in case there are no listed extensions in the directory.

**dir="$0"
selected_file="$1"**

Here, dir and selected_file are being set to the two arguments that are passed to the bash script at the end ("$PWD" and "$fx"). They are the working directory and the selected file, respectively.

**images=($(ls "$dir"/*.{jpg,jpeg,png,webp,bmp,tiff,tif,raw,ico,exif,heic,heif,gif,avif,jxl} | sort -V))**

The ls command lists all the files in the directory that have certain image extensions. This list of files is piped (|) to sort -V, which sorts the list in version number order (which is similar to natural order for filenames). This sorted list of images is stored in the images array.

 **[[ "${images[i]}" = "$selected_file" ]] && {
        sxiv -abiof "${images[@]:i}" "${images[@]:0:i}"
        break
    }
done**

This is a for loop that iterates over each image in the images array. For each image, it checks if the image equals the selected file. If it does, the sxiv command is executed with all images from the selected one to the end of the list, followed by all images from the start of the list to the selected one. This makes it possible to navigate through the images both forward and backward, preserving the order from lf. After this, the break command is used to exit the for loop because we've found our selected image.

The **"$PWD"** and **"$fx"** at the end are the arguments that are passed to the bash script. "$PWD" is the current working directory in lf, and "$fx" is the currently selected file in lf.

**${images[@]:i}**: This gives you all the elements in the images array starting from index i (which is the index of the selected image file) to the end of the array. In the images array, these are all the image files in the directory that come after (or are the same as) the selected file, in the order they are listed in lf.

**${images[@]:0:i}**: This gives you all the elements in the images array from the start of the array up to, but not including, index i. In the images array, these are all the image files in the directory that come before the selected file, in the correct order.