### PR TITLE
Fix arkenfox pacman hook complaining about root

### DIFF
--- a/.local/bin/arkenfox-auto-update
+++ b/.local/bin/arkenfox-auto-update
@@ -16,5 +16,8 @@ IFS='
 
 # Update each found profile.
 for profile in $profiles; do
-	arkenfox-updater -p "${profile%%/user.js*}" -s
+	userjs=${profile%%/user.js*}
+	user=$(stat -c '%U' "$userjs") || continue
+
+	su -l "$user" -c "arkenfox-updater -c -p $userjs -s"
 done


### PR DESCRIPTION
The previous pull request on LARBS turned out not to work, so make sure `arkenfox-auto-update` runs `arkenfox-update` as the user of the profile. Otherwise it complains that it's running as root and stops.

The way of getting the username is safe, because it gets the username from the owner of the user.js file of that profile.