### PR TITLE
Fix the extra space between sb-internet and block on the right

### DIFF
--- a/.local/bin/statusbar/sb-internet
+++ b/.local/bin/statusbar/sb-internet
@@ -25,9 +25,9 @@ elif [ "$(cat /sys/class/net/w*/operstate 2>/dev/null)" = 'down' ] ; then
 fi
 
 # Ethernet
-[ "$(cat /sys/class/net/e*/operstate 2>/dev/null)" = 'up' ] && ethericon="🌐 " || ethericon="❎ "
+[ "$(cat /sys/class/net/e*/operstate 2>/dev/null)" = 'up' ] && ethericon="🌐" || ethericon="❎"
 
 # TUN
-[ -n "$(cat /sys/class/net/tun*/operstate 2>/dev/null)" ] && tunicon="🔒 "
+[ -n "$(cat /sys/class/net/tun*/operstate 2>/dev/null)" ] && tunicon=" 🔒"
 
 printf "%s%s%s\n" "$wifiicon" "$ethericon" "$tunicon"


### PR DESCRIPTION
Accidentally introduced an extra space when there's a block on the right of sb-internet. This fixes it.