### PR TITLE
timeout forecase and moonphase at one second

### DIFF
--- a/.local/bin/statusbar/sb-forecast
+++ b/.local/bin/statusbar/sb-forecast
@@ -7,7 +7,7 @@ url="${WTTRURL:-wttr.in}"
 weatherreport="${XDG_CACHE_HOME:-$HOME/.cache}/weatherreport"
 
 # Get a weather report from 'wttr.in' and save it locally.
-getforecast() { curl -sf "$url/$LOCATION" > "$weatherreport" || exit 1; }
+getforecast() { curl -sfm 1 "$url/$LOCATION" > "$weatherreport" || exit 1; }
 
 # Forecast should be updated only once a day.
 checkforecast() {

--- a/.local/bin/statusbar/sb-moonphase
+++ b/.local/bin/statusbar/sb-moonphase
@@ -5,7 +5,7 @@
 moonfile="${XDG_DATA_HOME:-$HOME/.local/share}/moonphase"
 
 [ -s "$moonfile" ] && [ "$(stat -c %y "$moonfile" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] ||
-	{ curl -sf "wttr.in/?format=%m" > "$moonfile" || exit 1 ;}
+	{ curl -sfm 1 "wttr.in/?format=%m" > "$moonfile" || exit 1 ;}
 
 icon="$(cat "$moonfile")"
 


### PR DESCRIPTION
If there is a network disruption or downtime for the `wttr.in` service, the `curl` command should timeout. If the `curl` command does not have a timeout, it would prevent other dwmblocks from being updated while the `sb-forecast` or `sb-moonphase` hangs.

I chose the timeout to be 1 second to be consistent with other status bar scripts like `sb-price` and `sb-iplocate`. One second also makes sense because some dwmblock scripts update every second.