### PR TITLE
Fixed Booksplit for termux

### DIFF
--- a/.local/bin/booksplit
+++ b/.local/bin/booksplit
@@ -12,7 +12,7 @@ inputaudio="$1"
 ext="${1##*.}"
 
 # Get a safe file name from the book.
-escbook="$(echo "$booktitle" | iconv -cf UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
+escbook="$(echo "$booktitle" | iconv -c -f UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
 
 ! mkdir -p "$escbook" &&
     echo "Do you have write access in this directory?" &&
@@ -31,7 +31,7 @@ do
 	cmd="$cmd -metadata artist=\"$author\" -metadata title=\"$title\" -metadata album=\"$booktitle\" -metadata year=\"$year\" -metadata track=\"$track\" -metadata total=\"$total\" -ss \"$start\" -to \"$end\" -vn -c:a copy \"$file\" "
     fi
     title="$(echo "$x" | cut -d'	' -f2-)"
-    esctitle="$(echo "$title" | iconv -cf UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
+    esctitle="$(echo "$title" | iconv -c -f UTF-8 -t ASCII//TRANSLIT | tr -d '[:punct:]' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed "s/-\+/-/g;s/\(^-\|-\$\)//g")"
     track="$((track+1))"
     start="$end"
 done < "$2"


### PR DESCRIPTION
Apparently the -cf inside iconv tool on termux doesn't work. You have to seperate the -c and the -f in order to be able to use the script correctly on termux on android.

This probably also doesn't give issues on desktop. Please accept this pull request.

I made a issue about this here:
https://github.com/LukeSmithxyz/voidrice/issues/1357