### PR TITLE
lf-scope: adds SVG preview creating cache.

### DIFF
--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -29,6 +29,11 @@ case "$(file --dereference --brief --mime-type -- "$1")" in
 		CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/lf/thumb.$(stat --printf '%n\0%i\0%F\0%s\0%W\0%Y' -- "$(readlink -f "$1")" | sha256sum | cut -d' ' -f1)"
 		[ ! -f "$CACHE" ] && djvused "$1" -e 'select 1; save-page-with /dev/stdout' | convert -density 200 - "$CACHE.jpg" > /dev/null 2>&1
 		image "$CACHE.jpg" "$2" "$3" "$4" "$5" "$1" ;;
+image/svg+xml)
+	CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/lf/thumb.$(stat --printf '%n\0%i\0%F\0%s\0%W\0%Y' -- "$(readlink -f "$1")" | sha256sum | cut -d' ' -f1)"
+	[ ! -f "$CACHE" ] && inkscape --convert-dpi-method=none -o "$CACHE.png" --export-overwrite -D --export-png-color-mode=RGBA_16 "$1"
+	image "$CACHE.png" "$2" "$3" "$4" "$5" "$1"
+	;;
 	image/*) image "$1" "$2" "$3" "$4" "$5" "$1" ;;
 	text/html) lynx -width="$4" -display_charset=utf-8 -dump "$1" ;;
 	text/troff) man ./ "$1" | col -b ;;


### PR DESCRIPTION
This uses inkscape (v1.3) to convert. It's quick and does not open the GUI.