### PR TITLE
improve bulkrename in lf

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -95,24 +95,32 @@ cmd copyto ${{
 cmd setbg "$1"
 
 cmd bulkrename ${{
-    tmpfile_old="$(mktemp)"
-    tmpfile_new="$(mktemp)"
+tmpfile_old="$(mktemp)"
+tmpfile_new="$(mktemp)"
+tmpfile_ext="$(mktemp)"
 
-    [ -n "$fs" ] && fs=$(basename -a $fs) || fs=$(ls)
+[ -n "$fs" ] && fs=$(basename -a $fs | sort -fV) || fs=$(find . -maxdepth 1 -type f | cut -c 3- | sort -fV)
 
-    echo "$fs" > "$tmpfile_old"
-    echo "$fs" > "$tmpfile_new"
-    $EDITOR "$tmpfile_new"
+for f in $fs; do
+    echo "${f%.*}" >> "$tmpfile_old"
+    echo "${f##*.}" >> "$tmpfile_ext"
+done
 
-    [ "$(wc -l < "$tmpfile_old")" -eq "$(wc -l < "$tmpfile_new")" ] || { rm -f "$tmpfile_old" "$tmpfile_new"; exit 1; }
+cp "$tmpfile_old" "$tmpfile_new"
+$EDITOR "$tmpfile_new"
 
-    paste "$tmpfile_old" "$tmpfile_new" | while IFS="$(printf '\t')" read -r src dst
-    do
-        [ "$src" = "$dst" ] || [ -e "$dst" ] || mv -- "$src" "$dst"
-    done
+[ "$(wc -l < "$tmpfile_old")" -eq "$(wc -l < "$tmpfile_new")" ] || { rm -f "$tmpfile_old" "$tmpfile_new" "$tmpfile_ext"; exit 1; }
 
-    rm -f "$tmpfile_old" "$tmpfile_new"
-    lf -remote "send $id unselect"
+exec 3<"$tmpfile_old"
+exec 4<"$tmpfile_ext"
+exec 5<"$tmpfile_new"
+
+while IFS= read -r old_name <&3 && IFS= read -r ext <&4 && IFS= read -r new_name <&5; do
+    [ "$old_name" = "$new_name" ] || [ -e "$new_name.$ext" ] || mv -- "$old_name.$ext" "$new_name.$ext"
+done
+
+rm -f "$tmpfile_old" "$tmpfile_new" "$tmpfile_ext"
+lf -remote "send $id unselect"
 }}
 
 # Bindings


### PR DESCRIPTION
**<details>
<summary>You can see the example video here (15 seconds).</summary>

[bulkrename.webm](https://github.com/LukeSmithxyz/voidrice/assets/89175311/e67e70ce-b550-430f-bf18-279cf26fd622)
</details>**

## Improvements
- Directories are excluded. You can't mistakenly rename directories now or you don't have to exclude them manually.

- The extensions are excluded. Therefore, creating macros or editing in general is easier in the editor and there is no chance of messing up extensions. The extensions will be there as they are after editing.

## Justifications
- The original code fetched filenames without any specific order. In the new version, filenames are fetched in version sort order (sort -fV) to ensure a natural order, making it more intuitive for users. This is particularly useful when dealing with sequences of files (like episodes of a TV show or a series of images).

- Previously, the code used ls to get the file names. This approach can be problematic. The updated version uses find, a more robust and dependable method to retrieve files, and cut to trim the unnecessary ./ from the beginning. This change also helps us exclude directories from the list.

- It now separately stores the base filenames and their extensions. This prevents accidental renaming of file extensions, ensuring that only the desired part of the filename is modified. It adds an extra layer of precision, ensuring that a user doesn't mistakenly rename a file extension.

- It utilizes multiple file descriptors (3, 4, and 5) to read from the temporary files concurrently. This allows for a more structured loop when renaming files, making the code clearer and more maintainable. This removes the need for line by line operations and makes the process much more minimal and faster.

- The script can still work with Dash as a /bin/sh link.

## Performance Optimizations:
- The script still has minimal dependencies.

- Instead of reading and writing the entire content of files multiple times, the script uses the mktemp command to create temporary files and then employs file descriptors to read them concurrently. This minimizes file IO operations that can be a significant bottleneck.

- The script processes most data in-memory. Reading from and writing to memory is much faster than disk operations as you already know.

- The while loop uses file descriptors to read three files concurrently. This parallelization minimizes the number of loop iterations, making the loop more efficient than sequential alternatives.