### PR TITLE
Remove unessasary and counter-productive operation in sb-music

### DIFF
--- a/.local/bin/statusbar/sb-music
+++ b/.local/bin/statusbar/sb-music
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-filter() { sed "/^volume:/d;s/\\&/&amp;/g;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d;/^ERROR/Q" | paste -sd ' ' -;}
+filter() { sed "/^volume:/d;s/\\[paused\\].*/⏸/g;/\\[playing\\].*/d;/^ERROR/Q" | paste -sd ' ' -;}
 
 pidof -x sb-mpdup >/dev/null 2>&1 || sb-mpdup >/dev/null 2>&1 &
 


### PR DESCRIPTION
The s/\\&/&amp;/g operation only effect is to add "amp;" after any ampersand in the artist or song name. "&" displays just fine, so there's no reason to to replace it with anything.