### PR TITLE
dmenurecord fix for multiple displays

### DIFF
--- a/.local/bin/dmenurecord
+++ b/.local/bin/dmenurecord
@@ -9,7 +9,7 @@
 #
 # If there is already a running instance, user will be prompted to end it.
 
-getdim() { xrandr | sed -n "s/\s*\([0-9]\+x[0-9]\+\).*\*.*/\1/p" ;}
+getdim() { xrandr | grep -oP '(?<=current ).*(?=,)' | tr -d ' ' ;}
 
 updateicon() { \
 	echo "$1" > /tmp/recordingicon


### PR DESCRIPTION
Fixes #1361 by returning current screen's resolution. May not be perfect if someone wants to record one screen but it at least works