### PR TITLE
An unnecessary(?), small improvement for lf mkdir command

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -50,7 +50,7 @@ cmd open ${{
     esac
 }}
 
-cmd mkdir $mkdir -p "$(echo $* | tr ' ' '\ ')"
+cmd mkdir $mkdir -p "$@"
 
 cmd extract ${{
 	clear; tput cup $(($(tput lines)/3)); tput bold
@@ -139,7 +139,7 @@ map D delete
 map E extract
 map C copyto
 map M moveto
-map <c-n> push :mkdir<space>
+map <c-n> push :mkdir<space>""<left>
 map <c-r> reload
 map <c-s> set hidden!
 map <enter> shell


### PR DESCRIPTION
The new method is more robust and better handles directory names with spaces and special characters.

It's more minimal since we get rid of 2 commands.