### PR TITLE
lfrc - Added 5 new mappings, 3 of which pipe to clipboard

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -162,7 +162,14 @@ map V push :!nvim<space>
 
 map W $setsid -f $TERMINAL >/dev/null 2>&1
 
-map Y $printf "%s" "$fx" | xclip -selection clipboard
+map U $printf "%s" "$fx" | xclip -selection clipboard
+map u $printf "%s" "$fx" | sed 's/.*\///' | xclip -selection clipboard
+map . $printf "%s" "$fx" | sed -E 's/^.+\[/https:\/\/www.youtube.com\/watch?v=/' | sed -E 's/\]\..+//' | xclip -selection clipboard
+map <gt> $printf "%s" "$fx" | sed -E 's/^.+\[/https:\/\/piped.video\/watch?v=/' | sed -E 's/\]\..+//' | xclip -selection clipboard
+map T $sxiv -t "$(pwd)" # opens thumbnail mode
+map <c-l> unselect
+
+
 
 # Source Bookmarks
 source "~/.config/lf/shortcutrc"


### PR DESCRIPTION
1. Copies the selected filename (Y currently copies filepath, not filename), and pipes it to clipboard.

2. Copies the selected filename and if it matches the yt-dlp downloaded video format [1234567891011], gets the full youtube URL and pipes it to clipboard. For example, the file "_API calls in Godot 4 under 4 minutes [hC38DsPUDVk].mkv_" pipes the string "https://www.youtube.com/watch?v=hC38DsPUDVk" to the clipboard.

3. Copies the selected filename and if it matches the yt-dlp downloaded video format [1234567891011], gets the full piped.video URL and pipes it to the clipboard. (piped.video is a mirror of youtube, even includes comments)
For the same example file as above, it pipes the string "https://piped.video/watch?v=hC38DsPUDVk" to the clipboard.

4. Opens current folder in full picture mode (sxiv). Think windows large icons mode. Good for browsing quickly through image albums. Mapped to T character, which is intuitive (Thumbnails)

5. Ctrl+l to unselect all selections so the behaviour matches the terminal.