### PR TITLE
lfrc - Added hotkey which compresses selected videos (webm,mkv,mp4) via ffmpeg

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -93,7 +93,7 @@ cmd compressvideo ${{
    converted_files_count=0; #notify-send variable
 
    echo "Compression Rate? (default: 31, maximum: 50)";
-   read compressionRate;
+   read -N 2 compressionRate;
 
    #If not a number (e.g. empty), give default 31 value
    if ! [[ $compressionRate =~ ^[0-5][0-9]$ ]]; then

--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -96,10 +96,9 @@ cmd compressvideo ${{
    read compressionRate;
 
    #If not a number (e.g. empty), give default 31 value
-   #if ! [[ $cr =~ "^[0-5][0-9]$" ]]; then
-      #echo "IS NOT A NUMBER" && sleep 1;
-      #compressionRate="31";
-   #fi
+   if ! [[ $compressionRate =~ ^[0-5][0-9]$ ]]; then
+      compressionRate="31";
+   fi
 
    for pickedFilepath in $fx; do
       #could instead use ffprobe but would get more complicated as the filetype suffix becomes unknown

--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -85,6 +85,65 @@ cmd delete ${{
 	[ $ans = "y" ] && rm -rf -- $fx
 }}
 
+
+cmd compressvideo ${{
+   clear;
+   set -f;
+
+   is_mp4_already=0;
+   converted_filenames=""; #notify-send variable
+   converted_files_count=0; #notify-send variable
+   compressionRatio="31"; #30 is impossible to notice difference
+
+   echo "Compression Ratio? (default: 31, maximum: 50)";
+   read compressionRatio;
+
+   #If not a number (e.g. empty), give default 31 value
+   if ! [[ $compressionRatio =~ '^[0-9]+$' ]]; then
+      compressionRatio="31"
+   fi
+
+   for pickedFilepath in $fx; do
+      is_valid_filetype=0;
+
+      #could instead use ffprobe but would get more complicated as the filetype suffix becomes unknown
+      case $pickedFilepath in
+         *.mp4)
+            is_valid_filetype=1 && is_mp4_already=1;;
+         *.webm)
+            is_valid_filetype=1 && is_mp4_already=0;;
+         *.mkv)
+            is_valid_filetype=1 && is_mp4_already=0;;
+      esac
+
+      if [[ $is_valid_filetype -eq 0 ]]; then
+         continue 1 ;
+      fi;
+
+      if [[ $is_mp4_already -eq 1 ]]; then
+         tempFilepath=$(echo "$pickedFilepath" | sed 's|.mp4|(CONVERTING).mp4|');
+         mv -f "$pickedFilepath" "$tempFilepath";
+
+         ffmpeg -i "$tempFilepath" -vcodec libx265 -crf "$compressionRatio" "$pickedFilepath";
+         rm -f -- "$tempFilepath";
+      else
+         newFilepath=$(echo "$pickedFilepath" | sed 's/\(.webm\|.mkv\)/.mp4/');
+         ffmpeg -i "$pickedFilepath" -vcodec libx265 -crf "$compressionRatio" "$newFilepath";
+         rm -f -- "$pickedFilepath";
+      fi
+
+      ((converted_files_count=converted_files_count+1));
+      converted_filenames="$converted_filenames"$'\n'"$pickedFilepath";
+
+   done
+
+   #Notify the user of the results
+   if [[ $converted_files_count -gt 0 ]]; then
+      converted_filenames=$(echo "$converted_filenames" | sed 's|.*\/||');
+      notify-send "Compressed Videos($converted_files_count): $converted_filenames";
+   fi;
+}}
+
 cmd moveto ${{
 	clear; tput cup $(($(tput lines)/3)); tput bold
 	set -f
@@ -163,6 +222,8 @@ map V push :!nvim<space>
 map W $setsid -f $TERMINAL >/dev/null 2>&1
 
 map Y $printf "%s" "$fx" | xclip -selection clipboard
+
+map <a-x> compressvideo
 
 # Source Bookmarks
 source "~/.config/lf/shortcutrc"

--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -85,52 +85,40 @@ cmd delete ${{
 	[ $ans = "y" ] && rm -rf -- $fx
 }}
 
-
 cmd compressvideo ${{
    clear;
    set -f;
 
-   is_mp4_already=0;
    converted_filenames=""; #notify-send variable
    converted_files_count=0; #notify-send variable
-   compressionRatio="31"; #30 is impossible to notice difference
 
-   echo "Compression Ratio? (default: 31, maximum: 50)";
-   read compressionRatio;
+   echo "Compression Rate? (default: 31, maximum: 50)";
+   read compressionRate;
 
    #If not a number (e.g. empty), give default 31 value
-   if ! [[ $compressionRatio =~ '^[0-9]+$' ]]; then
-      compressionRatio="31"
-   fi
+   #if ! [[ $cr =~ "^[0-5][0-9]$" ]]; then
+      #echo "IS NOT A NUMBER" && sleep 1;
+      #compressionRate="31";
+   #fi
 
    for pickedFilepath in $fx; do
-      is_valid_filetype=0;
-
       #could instead use ffprobe but would get more complicated as the filetype suffix becomes unknown
       case $pickedFilepath in
          *.mp4)
-            is_valid_filetype=1 && is_mp4_already=1;;
-         *.webm)
-            is_valid_filetype=1 && is_mp4_already=0;;
-         *.mkv)
-            is_valid_filetype=1 && is_mp4_already=0;;
+		tempFilepath=$(echo "$pickedFilepath" | sed 's|.mp4|(CONVERTING).mp4|');
+		mv -f "$pickedFilepath" "$tempFilepath";
+
+		ffmpeg -i "$tempFilepath" -vcodec libx265 -crf "$compressionRate" "$pickedFilepath";
+		rm -f -- "$tempFilepath";
+		;;
+         *.webm | *.mkv)
+		newFilepath=$(echo "$pickedFilepath" | sed 's/\(.webm\|.mkv\)/.mp4/');
+		ffmpeg -i "$pickedFilepath" -vcodec libx265 -crf "$compressionRate" "$newFilepath";
+		rm -f -- "$pickedFilepath";
+		;;
+	 *)
+	   continue 1;;
       esac
-
-      if [[ $is_valid_filetype -eq 0 ]]; then
-         continue 1 ;
-      fi;
-
-      if [[ $is_mp4_already -eq 1 ]]; then
-         tempFilepath=$(echo "$pickedFilepath" | sed 's|.mp4|(CONVERTING).mp4|');
-         mv -f "$pickedFilepath" "$tempFilepath";
-
-         ffmpeg -i "$tempFilepath" -vcodec libx265 -crf "$compressionRatio" "$pickedFilepath";
-         rm -f -- "$tempFilepath";
-      else
-         newFilepath=$(echo "$pickedFilepath" | sed 's/\(.webm\|.mkv\)/.mp4/');
-         ffmpeg -i "$pickedFilepath" -vcodec libx265 -crf "$compressionRatio" "$newFilepath";
-         rm -f -- "$pickedFilepath";
-      fi
 
       ((converted_files_count=converted_files_count+1));
       converted_filenames="$converted_filenames"$'\n'"$pickedFilepath";
@@ -140,7 +128,7 @@ cmd compressvideo ${{
    #Notify the user of the results
    if [[ $converted_files_count -gt 0 ]]; then
       converted_filenames=$(echo "$converted_filenames" | sed 's|.*\/||');
-      notify-send "Compressed Videos($converted_files_count): $converted_filenames";
+      notify-send "Compressed Videos($converted_files_count):" "$converted_filenames";
    fi;
 }}
 


### PR DESCRIPTION
It is essentially a glorified `ffmpeg -i input.video -vcodec libx265 -crf "$compressionRatio" output.mp4`
1. It checks if a non-video file is selected (skips it)
2. It properly parses .mp4 to .mp4 (by temporarily renaming the original file)
3. Automatically deletes the original file, but only if it finished conversion (so you can safely interrupt this operation)
4. Notifies the user on completion (so you can mass-compress some olde folder and Super+Shift+9 and continue your work)

Mapped into a hotkey (Alt+x) because it fits near the extract. But change freely. Keep in mind it must not conflict the keymaps added in https://github.com/LukeSmithxyz/voidrice/pull/1374 and https://github.com/LukeSmithxyz/voidrice/pull/1373