### PR TITLE
Fixed lf shortcuts keybindings

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -155,6 +155,8 @@ map i :rename # before extension
 map a :rename; cmd-right # after extension
 map B bulkrename
 map b $setbg $f
+map f # Intentionally empty so zsh shortcuts apply
+map F # Intentionally empty so zsh shortcuts apply
 
 map <c-e> down
 map <c-y> up

--- a/.config/shell/bm-dirs
+++ b/.config/shell/bm-dirs
@@ -6,7 +6,7 @@ d   ${XDG_DOCUMENTS_DIR:-$HOME/Documents}
 dt  ${XDG_DATA_HOME:-$HOME/.local/share}
 rr  $HOME/.local/src
 h   $HOME
-m   ${XDG_MUSIC_DIR:-$HOME/Music}
+mm   ${XDG_MUSIC_DIR:-$HOME/Music}
 mn  /mnt
 pp  ${XDG_PICTURES_DIR:-$HOME/Pictures}
 sc  $HOME/.local/bin

--- a/.local/bin/shortcuts
+++ b/.local/bin/shortcuts
@@ -28,7 +28,7 @@ awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
 	printf(\"map g%s :cd %s<CR>\nmap t%s <tab>:cd %s<CR><tab>\nmap M%s <tab>:cd %s<CR><tab>:mo<CR>\nmap Y%s <tab>:cd %s<CR><tab>:co<CR> \n\",\$1,\$2, \$1, \$2, \$1, \$2, \$1, \$2)       >> \"$vifm_shortcuts\" ;
 	printf(\"config.bind(';%s', \42set downloads.location.directory %s ;; hint links download\42) \n\",\$1,\$2) >> \"$qute_shortcuts\" ;
 	printf(\"map g%s cd %s\nmap t%s tab_new %s\nmap m%s shell mv -v %%s %s\nmap Y%s shell cp -rv %%s %s \n\",\$1,\$2,\$1,\$2, \$1, \$2, \$1, \$2) >> \"$ranger_shortcuts\" ;
-	printf(\"map C%s cd \42%s\42 \n\",\$1,\$2)           >> \"$lf_shortcuts\" ;
+	printf(\"map f%s cd \42%s\42 \n\",\$1,\$2)           >> \"$lf_shortcuts\" ;
 	printf(\"cmap ;%s %s\n\",\$1,\$2)                    >> \"$vim_shortcuts\" }"
 
 # Format the `files` file in the correct syntax and sent it to both configs.
@@ -39,5 +39,5 @@ awk "!/^\s*#/ && !/^\s*\$/ {gsub(\"\\\s*#.*$\",\"\");
 	printf(\"abbr %s \42\$EDITOR %s\42 \n\",\$1,\$2) >> \"$fish_shortcuts\"  ;
 	printf(\"map %s :e %s<CR> \n\",\$1,\$2)          >> \"$vifm_shortcuts\"  ;
 	printf(\"map %s shell \$EDITOR %s \n\",\$1,\$2)  >> \"$ranger_shortcuts\" ;
-	printf(\"map E%s \$\$EDITOR \42%s\42 \n\",\$1,\$2)   >> \"$lf_shortcuts\" ;
+	printf(\"map F%s \$\$EDITOR \42%s\42 \n\",\$1,\$2)   >> \"$lf_shortcuts\" ;
 	printf(\"cmap ;%s %s\n\",\$1,\$2)                    >> \"$vim_shortcuts\" }"


### PR DESCRIPTION
**Supercedes** https://github.com/LukeSmithxyz/voidrice/pull/1239

The script at `.local/bin/shortcuts` generates shortcuts for shell, zsh, lf, vim. The changes you make are applied on saving (`:wq`) Open `.config/lf/lfrc` and look at that final line (which basically appends the above `.local/bin/shortcuts` generated mapping at the end of `lfrc`)

This purpose of this existing script is that all shortcuts are in one place (`;bd` `;bf` -> `.config/shell/bm-dirs`, `.config/shell/bm-files`)
So if you want to add a shortcut of a new folder or file, you **don't** have to copy-paste the mapping onto the config of lf, st, zsh, vim, **seperately**.

### The Problem

As explained in https://github.com/LukeSmithxyz/voidrice/pull/1239 the shortcut conflicts lf's `C` and `E`. `C` is mapped to `CopyTo`, `E` is mapped to `Extract`. **This means all shortcuts are disabled in lf**, as you press `C` for some directory but the `CopyTo` menu opens, and messes up your shortcuts.

The superseded issue (https://github.com/LukeSmithxyz/voidrice/pull/1239) fixed this by mapping it to `Ctrl+x` and `Ctrl+z`, but I find these mappings to be inefficient, as `LeftCtrl` is the hardest key to press with the left pinky, and `RightCtrl` is the slightly hard to press with the right pinky. Having mapped my own personal directories and files, I can confirm that this functionality is the most used alongside selection (spacebar) because I basically never go up or down (`j` `k`) to move to a different directory, so it makes no sense to have such core functionality in a 2-key press, instead of a single key-press.

The key `f` and `F` (find, find-back) are **needless**, because `/` and `?` do the exact same job. And `f` is the closest to `r` (`Super+r` opening lf, so the finger movement is minimal to move from `r` to `f` )

Also changed `m` to `mm` because `m` shortcut always overrides `mn` (shortcuts of longer length under the same characters are overriden)