### PR TITLE
Update sb-clock to fix display issue

### DIFF
--- a/.local/bin/statusbar/sb-clock
+++ b/.local/bin/statusbar/sb-clock
@@ -19,7 +19,7 @@ case "$clock" in
 esac
 
 case $BLOCK_BUTTON in
-	1) notify-send "This Month" "$(cal | sed "s/\<$(date +'%e')\>/<b><span color='red'>&<\/span><\/b>/")" && notify-send "Appointments" "$(calcurse -d3)" ;;
+	1) notify-send "This Month" "$(cal | sed "s/\<$(date +'%e'|sed 's/ //g')\>/<b><span color='red'>&<\/span><\/b>/")" && notify-send "Appointments" "$(calcurse -d3)" ;;
 	2) setsid -f "$TERMINAL" -e calcurse ;;
 	3) notify-send "📅 Time/date module" "\- Left click to show upcoming appointments for the next three days via \`calcurse -d3\` and show the month via \`cal\`
 - Middle click opens calcurse if installed" ;;


### PR DESCRIPTION
In sb-clock, if date of the month is < 9 the red selection doesn't work. Is is caused by space in `date '%e'` command. I fixed it by clearing spaces using sed

```
[stepan@thinkpad ~]$ cal | sed "s/\<$(date +'%e')\>/<b><span color='red'>&<\/span><\/b>/"
    December 2023
Su Mo Tu We Th Fr Sa
                1  2
 3  4  5  6  7  8  9
10 11 12 13 14 15 16
17 18 19 20 21 22 23
24 25 26 27 28 29 30
31
[stepan@thinkpad ~]$ cal | sed "s/\<$(date +'%e'|sed 's/ //g')\>/<b><span color='red'>&<\/span><\/b>/"
    December 2023
Su Mo Tu We Th Fr Sa
                1  2
 3  4  5  6  7  <b><span color='red'>8</span></b>  9
10 11 12 13 14 15 16
17 18 19 20 21 22 23
24 25 26 27 28 29 30
31
[stepan@thinkpad ~]$
```