### PR TITLE
Improve remapd detection

### DIFF
--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -4,5 +4,5 @@
 
 while :; do
 	remaps
-	watch -n1 -g xinput --list
+	watch -gn1 sh -c 'xinput --list | grep keyboard'
 done

--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 # Rerun the remaps script whenever a new input device is added.
 
 while :; do
 	remaps
-	grep -qP -m1 '[^un]bind.+\/[^:]+\(usb\)' <(udevadm monitor -u -t seat -s input -s usb)
+	watch -n1 -g xinput --list
 done

--- a/.local/bin/remapd
+++ b/.local/bin/remapd
@@ -4,5 +4,5 @@
 
 while :; do
 	remaps
-	watch -gn1 sh -c 'xinput --list | grep keyboard'
+	watch -gn1 sh -c 'xinput --list | grep keyboard' >/dev/null 2>&1
 done


### PR DESCRIPTION
Previously remapd would trigger whenever a USB device was attached. This patch changes that to only trigger the script when the output of `xinput --list | grep keyboard` changes. This has the added bonus of making the script posix compliant.