### PR TITLE
script fixes

### DIFF
--- a/.local/bin/lfub
+++ b/.local/bin/lfub
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This is a wrapper script for lb that allows it to create image previews with
+# This is a wrapper script for lf that allows it to create image previews with
 # ueberzug. This works in concert with the lf configuration file and the
 # lf-cleaner script.
 

--- a/.local/bin/statusbar/sb-battery
+++ b/.local/bin/statusbar/sb-battery
@@ -13,7 +13,7 @@ case $BLOCK_BUTTON in
 - Scroll to change adjust xbacklight." ;;
 	4) xbacklight -inc 10 ;;
 	5) xbacklight -dec 10 ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 # Loop through all attached batteries and format the info

--- a/.local/bin/statusbar/sb-clock
+++ b/.local/bin/statusbar/sb-clock
@@ -23,7 +23,7 @@ case $BLOCK_BUTTON in
 	2) setsid -f "$TERMINAL" -e calcurse ;;
 	3) notify-send "📅 Time/date module" "\- Left click to show upcoming appointments for the next three days via \`calcurse -d3\` and show the month via \`cal\`
 - Middle click opens calcurse if installed" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 date "+%Y %b %d (%a) $icon%I:%M%p"

--- a/.local/bin/statusbar/sb-cpu
+++ b/.local/bin/statusbar/sb-cpu
@@ -6,7 +6,7 @@ case $BLOCK_BUTTON in
 	3) notify-send "🖥 CPU module " "\- Shows CPU temperature.
 - Click to show intensive processes.
 - Middle click to open htop." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 sensors | awk '/Core 0/ {print "🌡" $3}'

--- a/.local/bin/statusbar/sb-cpubars
+++ b/.local/bin/statusbar/sb-cpubars
@@ -12,7 +12,7 @@ case $BLOCK_BUTTON in
 	2) setsid -f "$TERMINAL" -e htop ;;
 	3) notify-send "🪨 CPU load module" "Each bar represents
 one CPU core";;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 # id total idle

--- a/.local/bin/statusbar/sb-disk
+++ b/.local/bin/statusbar/sb-disk
@@ -11,7 +11,7 @@ case $BLOCK_BUTTON in
 	1) notify-send "💽 Disk space" "$(df -h --output=target,used,size)" ;;
 	3) notify-send "💽 Disk module" "\- Shows used hard drive space.
 - Click to show all disk info." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 case "$location" in

--- a/.local/bin/statusbar/sb-doppler
+++ b/.local/bin/statusbar/sb-doppler
@@ -274,7 +274,7 @@ case $BLOCK_BUTTON in
 	3) notify-send "🗺️ Doppler RADAR module" "\- Left click for local Doppler RADAR.
 - Middle click to update RADAR location.
 After $secs seconds, new clicks will also automatically update the doppler RADAR."  ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 echo 🌅

--- a/.local/bin/statusbar/sb-forecast
+++ b/.local/bin/statusbar/sb-forecast
@@ -45,7 +45,7 @@ case $BLOCK_BUTTON in
 ☔: Chance of rain/snow
 🥶: Daily low
 🌞: Daily high" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 checkforecast || getforecast

--- a/.local/bin/statusbar/sb-help-icon
+++ b/.local/bin/statusbar/sb-help-icon
@@ -13,5 +13,5 @@ case $BLOCK_BUTTON in
 	2) restartwm ;;
 	3) notify-send "❓ Help module" "\- Left click to open LARBS guide.
 - Middle click to refresh window manager." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac; echo "❓"

--- a/.local/bin/statusbar/sb-internet
+++ b/.local/bin/statusbar/sb-internet
@@ -14,7 +14,7 @@ case $BLOCK_BUTTON in
 🌐: ethernet working
 🔒: vpn is active
 " ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 # Wifi

--- a/.local/bin/statusbar/sb-kbselect
+++ b/.local/bin/statusbar/sb-kbselect
@@ -11,7 +11,7 @@ case $BLOCK_BUTTON in
 	pkill -RTMIN+30 "${STATUSBAR:-dwmblocks}";;
 	3) notify-send "⌨  Keyboard/language module" "$(printf "%s" "\- Current layout: $(setxkbmap -query | grep -oP 'layout:\s*\K\w+')")
 - Left click to change keyboard.";;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 echo "$kb"

--- a/.local/bin/statusbar/sb-mailbox
+++ b/.local/bin/statusbar/sb-mailbox
@@ -10,7 +10,7 @@ case $BLOCK_BUTTON in
 - Shows 🔃 if syncing mail
 - Left click opens neomutt
 - Middle click syncs mail" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 unread="$(find "${XDG_DATA_HOME:-$HOME/.local/share}"/mail/*/[Ii][Nn][Bb][Oo][Xx]/new/* -type f | wc -l 2>/dev/null)"

--- a/.local/bin/statusbar/sb-memory
+++ b/.local/bin/statusbar/sb-memory
@@ -6,7 +6,7 @@ case $BLOCK_BUTTON in
 	3) notify-send "🧠 Memory module" "\- Shows Memory Used/Total.
 - Click to show memory hogs.
 - Middle click to open htop." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 free --mebi | sed -n '2{p;q}' | awk '{printf ("🧠%2.2fGiB/%2.2fGiB\n", ( $3 / 1024), ($2 / 1024))}'

--- a/.local/bin/statusbar/sb-moonphase
+++ b/.local/bin/statusbar/sb-moonphase
@@ -33,5 +33,5 @@ case $BLOCK_BUTTON in
 - 🌖: Waning Gibbous
 - 🌗: Last Quarter
 - 🌘: Waning Crescent" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac

--- a/.local/bin/statusbar/sb-music
+++ b/.local/bin/statusbar/sb-music
@@ -14,6 +14,6 @@ case $BLOCK_BUTTON in
 - Scroll changes track.";;  # right click, pause/unpause
 	4) mpc prev   | filter ;;  # scroll up, previous
 	5) mpc next   | filter ;;  # scroll down, next
-	6) mpc status | filter ; "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) mpc status | filter ; setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 	*) mpc status | filter ;;
 esac

--- a/.local/bin/statusbar/sb-nettraf
+++ b/.local/bin/statusbar/sb-nettraf
@@ -8,7 +8,7 @@ case $BLOCK_BUTTON in
 	1) setsid -f "$TERMINAL" -e bmon ;;
 	3) notify-send "🌐 Network traffic module" "🔻: Traffic received
 🔺: Traffic transmitted" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 update() {

--- a/.local/bin/statusbar/sb-news
+++ b/.local/bin/statusbar/sb-news
@@ -11,7 +11,7 @@ case $BLOCK_BUTTON in
 - Left click opens newsboat
 - Middle click syncs RSS feeds
 <b>Note:</b> Only one instance of newsboat (including updates) may be running at a time." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
  cat /tmp/newsupdate 2>/dev/null || echo "$(newsboat -x print-unread | awk '{ if($1>0) print "📰" $1}')$(cat "${XDG_CONFIG_HOME:-$HOME/.config}"/newsboat/.update 2>/dev/null)"

--- a/.local/bin/statusbar/sb-news
+++ b/.local/bin/statusbar/sb-news
@@ -5,7 +5,7 @@
 
 case $BLOCK_BUTTON in
         1) setsid "$TERMINAL" -e newsboat ;;
-	2) setsid -f newsup >/dev/null exit ;;
+	2) setsid -f newsup >/dev/null && exit ;;
         3) notify-send "📰 News module" "\- Shows unread news items
 - Shows 🔃 if updating with \`newsup\`
 - Left click opens newsboat

--- a/.local/bin/statusbar/sb-pacpackages
+++ b/.local/bin/statusbar/sb-pacpackages
@@ -23,7 +23,7 @@ case $BLOCK_BUTTON in
 	3) notify-send "🎁 Upgrade module" "📦: number of upgradable packages
 - Left click to upgrade packages
 - Middle click to show upgradable packages" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 pacman -Qu | grep -Fcv "[ignored]" | sed "s/^/📦/;s/^📦0$//g"

--- a/.local/bin/statusbar/sb-price
+++ b/.local/bin/statusbar/sb-price
@@ -44,7 +44,7 @@ case $BLOCK_BUTTON in
 - Shows 🔃 if updating prices.
 - <b>Last updated:
 	$uptime</b>" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 [ -n "$updateme" ] &&

--- a/.local/bin/statusbar/sb-tasks
+++ b/.local/bin/statusbar/sb-tasks
@@ -13,7 +13,7 @@ case $BLOCK_BUTTON in
 	1) setsid -f "$TERMINAL" -e tsp -l ;;
 	3) notify-send "Tasks module" "🤖: number of running/queued background tasks
 - Left click opens tsp" ;; # Right click
-	2) $EDITOR "$0" ;; # Middle click
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 [ "$num" != "0(0)" ] &&

--- a/.local/bin/statusbar/sb-torrent
+++ b/.local/bin/statusbar/sb-torrent
@@ -23,5 +23,5 @@ Module shows number of torrents:
 🔽: downloading
 ✅: done
 🌱: done and seeding" ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac

--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -10,7 +10,7 @@ case $BLOCK_BUTTON in
 	3) notify-send "📢 Volume module" "\- Shows volume 🔊, 🔇 if muted.
 - Middle click to mute.
 - Scroll to change." ;;
-	6) "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 vol="$(wpctl get-volume @DEFAULT_AUDIO_SINK@)"


### PR DESCRIPTION
1. fix a typo in lfub
2. fix newsup exiting immediately when middle clicking the sb-news icon 
3. use setsid -f when editing statusbar scripts. this means you can interact with the scripts and see the changes you make without closing your editor.