### PR TITLE
[getcomproot] - fix | minimize | posix compliance

### DIFF
--- a/.local/bin/getcomproot
+++ b/.local/bin/getcomproot
@@ -1,12 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # A helper script for LaTeX/groff files used by `compiler` and `opout`.
 # The user can add the root file of a larger project as a comment as below:
 # % root = mainfile.tex
 # And the compiler script will run on that instead of the opened file.
 
-texroot="$(grep -i "^.\+\s*root\s*=\s*\S\+" "$1")"
-texroot="${texroot##*=}"
-texroot="${texroot//[\"\' ]}"
-
-[ -f "$texroot" ] && readlink -f "$texroot" || exit 1
+texroot="$(sed -n 's/^\s*%.*root\s*=\s*\(\S\+\).*/\1/p' "${1}")"
+[ -f "${texroot}" ] && readlink -f "${texroot}" || exit "1"


### PR DESCRIPTION
The old behavior can return wrong variables. Example:

First variable named texroot outputs:
`% root = main.tex PARTITION_ROOT="$(findmnt -n -o SOURCE /)" UUID_ROOT="$(blkid -s UUID -o value "$PARTITION_ROOT")" PARTUUID_ROOT="$(blkid -s PARTUUID -o value "$PARTITION_ROOT")"`

Second:
`"$(blkid -s PARTUUID -o value "$PARTITION_ROOT")"`

Third:
`$(blkid-sPARTUUID-ovalue$PARTITION_ROOT)`

Right now, the script is more minimal, posix compliant and outputs the file correctly:
`main.tex`

