### PR TITLE
Update sb-internet

### DIFF
--- a/.local/bin/statusbar/sb-internet
+++ b/.local/bin/statusbar/sb-internet
@@ -25,7 +25,7 @@ elif [ "$(cat /sys/class/net/w*/operstate 2>/dev/null)" = 'down' ] ; then
 fi
 
 # Ethernet
-[ "$(cat /sys/class/net/e*/operstate 2>/dev/null)" = 'up' ] && ethericon="🌐" || ethericon="❎"
+[ "$(cat /sys/class/net/e*/operstate 2>/dev/null | grep "up")" = 'up' ] && ethericon="🌐" || ethericon="❎"
 
 # TUN
 [ -n "$(cat /sys/class/net/tun*/operstate 2>/dev/null)" ] && tunicon=" 🔒"


### PR DESCRIPTION
Fix ethernet icon for systems with multiple NICs wherein `cat /sys/class/net/e*/operstate ` outputs multiple lines. Icon now shows connected when one or more NICs are connected.