### PR TITLE
newsup fix

### DIFF
--- a/.local/bin/cron/newsup
+++ b/.local/bin/cron/newsup
@@ -5,7 +5,7 @@
 
 /usr/bin/notify-send "📰 Updating RSS feeds..."
 
-pgrep -f newsboat$ && /usr/bin/xdotool key --window "$(/usr/bin/xdotool search --name "^newsboat$")" R && exit
+pgrep -fx newsboat && /usr/bin/xdotool key --window "$(/usr/bin/xdotool search --name "^newsboat$")" R && exit
 
 echo 🔃 > /tmp/newsupdate
 pkill -RTMIN+6 "${STATUSBAR:-dwmblocks}"


### PR DESCRIPTION
if the newsboat man page or config were open, pgrep would find that process and the R keypress would be sent instead of your feeds being reloaded. this is fixed by using -x which will only match the exact newsboat process.