### PR TITLE
Fix the problem when taking a screenshot of the lf window

### DIFF
--- a/.local/bin/maimpick
+++ b/.local/bin/maimpick
@@ -10,7 +10,7 @@ xclip_cmd="xclip -sel clip -t image/png"
 
 case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
     "a selected area") maim -u -s pic-selected-"${output}" ;;
-    "current window") maim -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"${output}" ;;
+    "current window") maim -B -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"${output}" ;;
     "full screen") maim -q -d 0.2 pic-full-"${output}" ;;
     "a selected area (copy)") maim -u -s | ${xclip_cmd} ;;
     "current window (copy)") maim -q -d 0.2 -i "$(xdotool getactivewindow)" | ${xclip_cmd} ;;


### PR DESCRIPTION
Without `-B` option, the result of the screenshot is a blank picture.