### PR TITLE
Removing the need of ~/.zprofile

### DIFF
--- a/.config/zsh/.zprofile
+++ b/.config/zsh/.zprofile
@@ -1,0 +1,1 @@
+../shell/profile


### PR DESCRIPTION
When we have this, and `/etc/zsh/zshenv` containing: ZDOTDIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
then we will not need ~/.zprofile