### PR TITLE
lf - add application/javascript mimetype to allow opening js files with $EDITOR

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -31,7 +31,7 @@ cmd open ${{
     case $(file --mime-type "$(readlink -f $f)" -b) in
 	application/vnd.openxmlformats-officedocument.spreadsheetml.sheet) localc $fx ;;
 	image/vnd.djvu|application/pdf|application/octet-stream|application/postscript) setsid -f zathura $fx >/dev/null 2>&1 ;;
-        text/*|application/json|inode/x-empty|application/x-subrip) $EDITOR $fx;;
+        text/*|application/json|application/javascript|inode/x-empty|application/x-subrip) $EDITOR $fx;;
 	image/x-xcf) setsid -f gimp $f >/dev/null 2>&1 ;;
 	image/svg+xml) display -- $f ;;
 	image/*) rotdir $f | grep -i "\.\(png\|jpg\|jpeg\|gif\|webp\|avif\|tif\|ico\)\(_large\)*$" |


### PR DESCRIPTION
Pressing `l` does not open javascript files as the mimetype for javascript files is "application/javascript" and the wildcard "text/*" does not include js files.