### PR TITLE
Save command to Zsh history before it is executed

### DIFF
--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -11,6 +11,7 @@ setopt interactive_comments
 HISTSIZE=10000000
 SAVEHIST=10000000
 HISTFILE="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/history"
+setopt inc_append_history
 
 # Load aliases and shortcuts if existent.
 [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/shell/shortcutrc" ] && source "${XDG_CONFIG_HOME:-$HOME/.config}/shell/shortcutrc"


### PR DESCRIPTION
I found it annoying when surfing in `lf` with `ctrl-o` in zsh, it would not save the history from the session before `ctrl-o`.

The option `setopt inc_append_history` fixes it by writing every command to history before it is executed. Consider also using `setopt share_history` which does the same thing but also reads the history, allowing sharing history between terminal sessions.