### PR TITLE
Fix sb-volume (toggle mute, scroll volume change)

### DIFF
--- a/.local/bin/statusbar/sb-volume
+++ b/.local/bin/statusbar/sb-volume
@@ -4,9 +4,9 @@
 
 case $BLOCK_BUTTON in
 	1) setsid -w -f "$TERMINAL" -e pulsemixer; pkill -RTMIN+10 "${STATUSBAR:-dwmblocks}" ;;
-	2) wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle ;;
-	4) wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%+ ;;
-	5) wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%- ;;
+	2) wpctl set-mute @DEFAULT_SINK@ toggle ;;
+	4) wpctl set-volume @DEFAULT_SINK@ 1%+ ;;
+	5) wpctl set-volume @DEFAULT_SINK@ 1%- ;;
 	3) notify-send "📢 Volume module" "\- Shows volume 🔊, 🔇 if muted.
 - Middle click to mute.
 - Scroll to change." ;;


### PR DESCRIPTION
the current wpctl version does not support @DEFAULT_AUDIO_SINK@, but works with @DEFAULT_SINK@

quick fix