### PR TITLE
map gh fix

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -139,7 +139,7 @@ cmd bulkrename ${{
 # Bindings
 map <c-f> $lf -remote "send $id select \"$(fzf)\""
 map J $lf -remote "send $id cd $(sed -e 's/\s*#.*//' -e '/^$/d' -e 's/^\S*\s*//' ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf)"
-map gh
+map H cd ~
 map g top
 map D delete
 map E extract


### PR DESCRIPTION
map gh doesn't do anything because it doesn't recognize multi-letter commands. mapping H to cd to ~