### PR TITLE
Enable wrap-around scrolling

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -25,6 +25,8 @@ set hiddenfiles ".*:*.aux:*.log:*.bbl:*.bcf:*.blg:*.run.xml"
 set cleaner '~/.config/lf/cleaner'
 set previewer '~/.config/lf/scope'
 set autoquit true
+# Enable wrap-around scrolling
+set wrapscroll true
 
 # cmds/functions
 cmd open ${{


### PR DESCRIPTION
It was getting annoying having to scroll up and down a big list of files or directories. LF has a built-in wrap around function