### PR TITLE
(lf,maimpick) added preview for .xcf files, fixed OCR selection in dmenu script

### DIFF
--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -30,6 +30,11 @@ image/svg+xml)
 	[ ! -f "$CACHE" ] && inkscape --convert-dpi-method=none -o "$CACHE.png" --export-overwrite -D --export-png-color-mode=RGBA_16 "$1"
 	image "$CACHE.png" "$2" "$3" "$4" "$5" "$1"
 	;;
+  image/x-xcf)
+    CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/lf/thumb.$(stat --printf '%n\0%i\0%F\0%s\0%W\0%Y' -- "$(readlink -f "$1")" | sha256sum | awk '{print $1}')"
+    [ ! -f "$CACHE.jpg" ] && convert "$1[0]" "$CACHE.jpg"
+    image "$CACHE.jpg" "$2" "$3" "$4" "$5" "$1"
+  ;;
 	image/*) image "$1" "$2" "$3" "$4" "$5" "$1" ;;
 	text/html) lynx -width="$4" -display_charset=utf-8 -dump "$1" ;;
 	text/troff) man ./ "$1" | col -b ;;

--- a/.local/bin/maimpick
+++ b/.local/bin/maimpick
@@ -9,7 +9,7 @@ output="$(date '+%y%m%d-%H%M-%S').png"
 xclip_cmd="xclip -sel clip -t image/png"
 ocr_cmd="xclip -sel clip"
 
-case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)" | dmenu -l 6 -i -p "Screenshot which area?")" in
+case "$(printf "a selected area\\ncurrent window\\nfull screen\\na selected area (copy)\\ncurrent window (copy)\\nfull screen (copy)\\nOCR a selected area (copy)" | dmenu -l 7 -i -p "Screenshot which area?")" in
     "a selected area") maim -u -s pic-selected-"${output}" ;;
     "current window") maim -B -q -d 0.2 -i "$(xdotool getactivewindow)" pic-window-"${output}" ;;
     "full screen") maim -q -d 0.2 pic-full-"${output}" ;;


### PR DESCRIPTION
- Added preview for `.xcf` files by using `convert`.
- Fixed `maimpick` not picking up the OCR option as the case hadn't been enabled in the script.