### PR TITLE
For ImageMagick 6 <-> 7 compatibility.

### DIFF
--- a/.config/lf/scope
+++ b/.config/lf/scope
@@ -13,6 +13,11 @@ image() {
 	fi
 }
 
+# For ImageMagick 6 <-> 7 compatibility.
+if type magick >/dev/null 2>&1; then
+    alias convert='magick'
+fi
+
 # Note that the cache file name is a function of file information, meaning if
 # an image appears in multiple places across the machine, it will not have to
 # be regenerated once seen.

--- a/.config/nsxiv/exec/key-handler
+++ b/.config/nsxiv/exec/key-handler
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# For ImageMagick 6 <-> 7 compatibility.
+if type magick >/dev/null 2>&1; then
+    alias convert='magick'
+fi
+
 while read -r file
 do
         case "$1" in

--- a/.local/bin/slider
+++ b/.local/bin/slider
@@ -70,6 +70,11 @@ if [ -n "${audio+x}" ]; then
 	endtime="$((totseconds-seconds))"
 fi
 
+# For ImageMagick 6 <-> 7 compatibility.
+if type magick >/dev/null 2>&1; then
+    alias convert='magick'
+fi
+
 prepdir="${prepdir:-$cache/$file}"
 outfile="${outfile:-$file.mp4}"
 prepfile="$prepdir/$file.prep"


### PR DESCRIPTION
The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"