### PR TITLE
Fix sb-price after bash -> dash change

### DIFF
--- a/.local/bin/statusbar/sb-price
+++ b/.local/bin/statusbar/sb-price
@@ -28,7 +28,9 @@ filestat="$(stat -c %x "$pricefile" 2>/dev/null)"
 
 [ -d "$dir" ] || mkdir -p "$dir"
 
-updateprice() { curl -sf -m 1 --fail-early $denom.$url/{1$target,$target$interval} --output "$pricefile" --output "$chartfile" ||
+updateprice() { curl -sf \
+	--fail-early "${denom}.${url}/1${target}" "${denom}.${url}/${target}${interval}" \
+	--output "$pricefile" --output "$chartfile" ||
 	rm -f "$pricefile" "$chartfile" ;}
 
 [ "${filestat%% *}" != "$(date '+%Y-%m-%d')" ] &&


### PR DESCRIPTION
After the /bin/sh symlink change from bash to dash, sb-price only showed $0.00 in the statusbar. This was because the substitution in the curl command is a bashism. This PR fixes it by replacing the substitution, through fully writing it out. It also stops shellcheck from complaining.