### PR TITLE
Latexmk 

### DIFF
--- a/.config/latexmk/latexmkrc
+++ b/.config/latexmk/latexmkrc
@@ -1,0 +1,10 @@
+$bibtex_use = 1.5;
+$cleanup_includes_cusdep_generated = 1;
+$cleanup_includes_generated = 1;
+$out_dir = "out";
+$pdf_mode = 5;
+$silent = 1;
+
+# SyncTeX
+push(@generated_exts, ("synctex.*"));
+push(@extra_xelatex_options, '-synctex=1') ;

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -91,7 +91,7 @@ colorscheme vim
 	map <leader>p :!opout "%:p"<CR>
 
 " Runs a script that cleans out tex build files whenever I close out of a .tex file.
-	autocmd VimLeave *.tex !texclear %
+	autocmd VimLeave *.tex !latexmk -c %
 
 " Ensure files are read as what I want:
 	let g:vimwiki_ext2syntax = {'.Rmd': 'markdown', '.rmd': 'markdown','.md': 'markdown', '.markdown': 'markdown', '.mdown': 'markdown'}

--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -6,9 +6,6 @@
 # Compiles .tex. groff (.mom, .ms), .rmd, .md, .org.  Opens .sent files as sent
 # presentations. Runs scripts based on extension or shebang.
 
-# Note that .tex files which you wish to compile with XeLaTeX should have the
-# string "xelatex" somewhere in a comment/command in the first 5 lines.
-
 file="${1}"
 ext="${file##*.}"
 dir=${file%/*}
@@ -38,15 +35,6 @@ case "${ext}" in
     sass) sassc -a "${file}" "${base}.css" ;;
     scad) openscad -o "${base}.stl" "${file}" ;;
     sent) setsid -f sent "${file}" 2> "/dev/null" ;;
-    tex)
-	    textarget="$(getcomproot "${file}" || echo "${file}")"
-	    command="pdflatex"
-	    head -n5 "${textarget}" | grep -qi "xelatex" && command="xelatex"
-	    ${command} --output-directory="${textarget%/*}" "${textarget%.*}" &&
-	    grep -qi addbibresource "${textarget}" &&
-	    biber --input-directory "${textarget%/*}" "${textarget%.*}" &&
-	    ${command} --output-directory="${textarget%/*}" "${textarget%.*}" &&
-	    ${command} --output-directory="${textarget%/*}" "${textarget%.*}"
-	    ;;
+    tex) latexmk ;;
     *) sed -n '/^#!/s/^#!//p; q' "${file}" | xargs -r -I % "${file}" ;;
 esac

--- a/.local/bin/texclear
+++ b/.local/bin/texclear
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Clears the build files of a LaTeX/XeLaTeX build.
-# I have vim run this file whenever I exit a .tex file.
-
-[ "${1##*.}" = "tex" ] && {
-	find "$(dirname "${1}")" -regex '.*\(_minted.*\|.*\.\(4tc\|xref\|tmp\|pyc\|pyg\|pyo\|fls\|vrb\|fdb_latexmk\|bak\|swp\|aux\|log\|synctex\(busy\)\|lof\|lot\|maf\|idx\|mtc\|mtc0\|nav\|out\|snm\|toc\|bcf\|run\.xml\|synctex\.gz\|blg\|bbl\)\)' -delete
-} || printf "Provide a .tex file.\n"
-


### PR DESCRIPTION
Removes `texclear` and simplifies `compiler` by using `latexmk`. Compared to the previous version, this `latexmk` configuration:

- Sets the default format to XeLaTeX (`$pdf_mode = 5`).
- Compiles in silent mode; errors can still be found in the log file.
- Autodetects Biber/BibTeX, using Biber for BibLaTeX.
- Calls Biber/BibTeX only if the bib files exist, reducing compiler calls by one.
- Outputs all compiled artifacts to `out`; simply add it to your `.gitignore` instead of listing numerous files.
- Simplifies configuration overwriting by adding a `.latexmkrc` file to the root of any LaTeX project; `VimLeave` and `compile` will read those.
- Automatically detects compiled artifacts to delete during cleanup, thanks to `$cleanup_includes_cusdep_generated` and `$cleanup_includes_generated` (goodbye `texclear`).