### PR TITLE
aliasrc  |  improve se()

### DIFF
--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -14,7 +14,7 @@ for command in mount umount sv pacman updatedb su shutdown poweroff reboot ; do
 done; unset command
 
 se() {
-	s=("${HOME}/.local/bin/"*)
+	s=("${HOME}/.local/bin/"**/*(.))
 	c="$(print -lnr ${s:t:r} | fzf)"
 	[[ "${c}" ]] && "${EDITOR}" ${${(M)s:#*/${c}*}[1]}
 }

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -14,9 +14,10 @@ for command in mount umount sv pacman updatedb su shutdown poweroff reboot ; do
 done; unset command
 
 se() {
-	choice="$(find ~/.local/bin -mindepth 1 -printf '%P\n' | fzf)"
-	[ -f "$HOME/.local/bin/$choice" ] && $EDITOR "$HOME/.local/bin/$choice"
-	}
+	s=("${HOME}/.local/bin/"*)
+	c="$(print -lnr ${s:t:r} | fzf)"
+	[[ "${c}" ]] && "${EDITOR}" ${${(M)s:#*/${c}*}[1]}
+}
 
 # Verbosity and settings that you pretty much just always are going to want.
 alias \


### PR DESCRIPTION
1. Remove external commands like `find`.
2. Remove extensions (possibly `.sh`) and path (`/home/username/.local/bin/`) from the names in `fzf`.
3. Only open the editor if there is a selection.

Do all of these without using `find`, `sed`, `grep`.

- First line creates an array with the files in the scripts directory.

- Second line removes path `:t` and the extensions `:r` from the scripts.

- `[[ "${c}" ]]` checks if this variable is non-empty.

- `${${(M)s:#*/${c}*}[1]} ` This works like `grep`

`(M)` enables "match" mode.
`:#` anchors the pattern to the start of each array element.
`*/${c}*` matches any path containing the selected basename.
`[1]` selects the first matching item.