### PR TITLE
add extra octet-stream video playback support

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -49,7 +49,7 @@ cmd open ${{
         application/octet-stream) case ${f##*.} in
 			doc|docx|xls|xlsx|odt|ppt|pptx) setsid -f libreoffice $fx >/dev/null 2>&1 ;;
 			ghw) setsid -f gtkwave $f >/dev/null 2>&1 ;;
-			ts) setsid -f mpv $f -quiet >/dev/null 2>&1 ;;
+			mkv|mp4|ts|webm) setsid -f mpv $f -quiet >/dev/null 2>&1 ;;
 			*) setsid -f zathura $fx >/dev/null 2>&1 ;;
 	   	esac ;;
 	*) for f in $fx; do setsid -f $OPENER $f >/dev/null 2>&1; done;;


### PR DESCRIPTION
Sometimes when downloading a stream it gets interrupted and the video file remains in MPEG-TS format but has a .mp4 ,.mkv,or .webm extension. This will allow the videos to play as is without having to spend a lot of time converting them with ffmpeg.