### PR TITLE
Update compiler to include instruction for the Rink calculator

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -20,6 +20,7 @@ case "${ext}" in
     [0-9]) preconv "${file}" | refer -PS -e | groff -mandoc -T pdf > "${base}.pdf" ;;
     mom|ms) preconv "${file}" | refer -PS -e | groff -T pdf -m"${ext}" > "${base}.pdf" ;;
     c) cc "${file}" -o "${base}" && "./${base}" ;;
+    cob) cobc -x -o "$base" "$file" && "$base" ;;
     cpp) g++ "${file}" -o "${base}" && "./${base}" ;;
     cs) mcs "${file}" && mono "${base}.exe" ;;
     go) go run "${file}" ;;

--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -33,6 +33,7 @@ case "${ext}" in
 	    pandoc -t ms --highlight-style="kate" -s -o "${base}.pdf" "${file}" ;;
     org) emacs "${file}" --batch -u "${USER}" -f org-latex-export-to-pdf ;;
     py) python "${file}" ;;
+    rink) rink -f "${file}" ;;
     [rR]md) Rscript -e "rmarkdown::render('${file}', quiet=TRUE)" ;;
     rs) cargo build ;;
     sass) sassc -a "${file}" "${base}.css" ;;


### PR DESCRIPTION
Added a compiler option for rink calculator files. Rink is a unit-conversion calculator written in Rust.