### PR TITLE
Fix UI rendering issues in neovim

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -63,7 +63,8 @@ colorscheme vim
 	endif
 	let g:airline_symbols.colnr = ' C:'
 	let g:airline_symbols.linenr = ' L:'
-	let g:airline_symbols.maxlinenr = '☰ '
+	let g:airline_symbols.maxlinenr = ' '
+	let g:airline#extensions#whitespace#symbol = '!'
 
 " Shortcutting split navigation, saving a keypress:
 	map <C-h> <C-w>h


### PR DESCRIPTION
Neovim started showing UI rendering issues after the latest update. Some of the Unicode characters used in the vim-airline plugin were found to be the cause, this commit aims to solve the issue by removing those characters.

Check this issue for more details - https://github.com/vim-airline/vim-airline/issues/2704