### PR TITLE
Fix rssget shebang

### DIFF
--- a/.local/bin/rssget
+++ b/.local/bin/rssget
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Searches the website for RSS feeds and adds them to newsboat url list. Can
 # also find hidden RSS feeds on various websites, namely Youtube, Reddit,


### PR DESCRIPTION
The script introduced in PR #1430 was mistakenly marked with `/bin/sh`, even though it uses several bashisms and isn't POSIX-compliant.

This change updates the shebang to `/bin/bash`, ensuring that the script is executed with the intended shell and preventing compatibility issues on systems where `/bin/sh` is not linked to Bash.
