### PR TITLE
aliasrc fixes

### DIFF
--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -10,12 +10,14 @@
 
 # sudo not required for some system commands
 for command in mount umount sv pacman updatedb su shutdown poweroff reboot ; do
+	# shellcheck disable=SC2139
 	alias $command="sudo $command"
 done; unset command
 
 se() {
 	local -r bindir=~sc/
 	s=("${bindir}"**/*(.))
+	# shellcheck disable=SC2086
 	c="$(print -lnr ${s/$bindir/} | fzf)"
 	[[ "${c}" ]] && "${EDITOR}" "$bindir$c"
 }

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -14,9 +14,10 @@ for command in mount umount sv pacman updatedb su shutdown poweroff reboot ; do
 done; unset command
 
 se() {
-	s=("${HOME}/.local/bin/"**/*(.))
-	c="$(print -lnr ${s:t:r} | fzf)"
-	[[ "${c}" ]] && "${EDITOR}" ${${(M)s:#*/${c}*}[1]}
+	local -r bindir=~sc/
+	s=("${bindir}"**/*(.))
+	c="$(print -lnr ${s/$bindir/} | fzf)"
+	[[ "${c}" ]] && "${EDITOR}" "$bindir$c"
 }
 
 # Verbosity and settings that you pretty much just always are going to want.

--- a/.config/shell/aliasrc
+++ b/.config/shell/aliasrc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/zsh
 
 # Use neovim for vim if present.
 [ -x "$(command -v nvim)" ] && alias vim="nvim" vimdiff="nvim -d"


### PR DESCRIPTION
- changed shebang to `/bin/zsh` since `se()` uses zshisms ([known since last rework](https://github.com/LukeSmithxyz/voidrice/pull/1433#discussion_r1874109275))
- prevents editing the wrong script with `se`
  - we were matching file names against a path-less, extension-less file name `c` (`{${(M)s:#*/${c}*}`), leading to incorrect matches. For example, if you have a script `cron/sdo` and choose `sd` in `fzf` you'll edit `sdo`
  - now we trim `~sc/` from the full path to display a partial path and keep the extensions
    - this is especially useful if you have more than one script with the same base name
- shellcheck ignores to avoid two misleading messages

I've provided a less verbose version of this explanation in the commit messages as well.

Edit: bash -> zsh