### PR TITLE
Improve Tridactyl search and scrolling

### DIFF
--- a/.config/tridactyl/tridactylrc
+++ b/.config/tridactyl/tridactylrc
@@ -1,0 +1,10 @@
+" Scrolling
+bind j scrollpx 0 50
+bind k scrollpx 0 -50
+
+" Search
+bind / fillcmdline find
+bind ? fillcmdline find -?
+bind n findnext 1
+bind N findnext -1
+bind ,<Space> nohlsearch


### PR DESCRIPTION
This makes it match the behavior of Vim Vixen. The "Search" section is taken from [this comment](https://github.com/tridactyl/tridactyl/issues/64#issuecomment-496913151). The maintainer also provides [a set of useful improvements](https://github.com/tridactyl/tridactyl/blob/master/.tridactylrc) for specific websites, I'm leaving them out on purpose for this PR.

This PR depends on the package from [this LARBS' PR](https://github.com/LukeSmithxyz/LARBS/pull/580).