### PR TITLE
Add support for hidden images if initial file is hidden

### DIFF
--- a/.local/bin/rotdir
+++ b/.local/bin/rotdir
@@ -9,4 +9,11 @@
 
 [ -z "$1" ] && echo "usage: rotdir regex 2>&1" && exit 1
 base="$(basename "$1")"
-ls "$PWD" | awk -v BASE="$base" 'BEGIN { lines = ""; m = 0; } { if ($0 == BASE) { m = 1; } } { if (!m) { if (lines) { lines = lines"\n"; } lines = lines""$0; } else { print $0; } } END { print lines; }'
+
+if [[ "$base" == .* ]]; then
+  ls_opt="ls -a"
+else
+  ls_opt="ls"
+fi
+
+$ls_opt "$PWD" | awk -v BASE="$base" 'BEGIN { lines = ""; m = 0; } { if ($0 == BASE) { m = 1; } } { if (!m) { if (lines) { lines = lines"\n"; } lines = lines""$0; } else { print $0; } } END { print lines; }'

--- a/.local/bin/rotdir
+++ b/.local/bin/rotdir
@@ -10,10 +10,9 @@
 [ -z "$1" ] && echo "usage: rotdir regex 2>&1" && exit 1
 base="$(basename "$1")"
 
-if [[ "$base" == .* ]]; then
-  ls_opt="ls -a"
-else
-  ls_opt="ls"
-fi
+case "$base" in
+  .*) ls_opt="ls -a" ;;
+  *) ls_opt="ls" ;;
+esac
 
 $ls_opt "$PWD" | awk -v BASE="$base" 'BEGIN { lines = ""; m = 0; } { if ($0 == BASE) { m = 1; } } { if (!m) { if (lines) { lines = lines"\n"; } lines = lines""$0; } else { print $0; } } END { print lines; }'


### PR DESCRIPTION
If the initial image is hidden, the script uses ls -a to include other hidden files; otherwise, it uses the default behaviour.