### PR TITLE
Let opout look at subdirs

### DIFF
--- a/.local/bin/opout
+++ b/.local/bin/opout
@@ -7,7 +7,12 @@
 basename="${1%.*}"
 
 case "${*}" in
-	*.tex|*.sil|*.m[dse]|*.[rR]md|*.mom|*.[0-9]) target="$(getcomproot "$1" || echo "$1")" ; setsid -f xdg-open "${target%.*}".pdf >/dev/null 2>&1 ;;
+	*.tex|*.sil|*.m[dse]|*.[rR]md|*.mom|*.[0-9])
+		target="$(getcomproot "$1" || echo "$1")"
+		target="${target##*/}"
+		target="$(find . -name "${target%.*}".pdf | head -n 1)"
+		setsid -f xdg-open "$target" >/dev/null 2>&1
+		;;
 	*.html) setsid -f "$BROWSER" "$basename".html >/dev/null 2>&1 ;;
 	*.sent) setsid -f sent "$1" >/dev/null 2>&1 ;;
 esac


### PR DESCRIPTION
Thanks to @v3natio for reporting this bug (see [their comment](https://github.com/LukeSmithxyz/voidrice/pull/1443#issuecomment-2745191652)).

The `opout` script will now look for compiled PDFs in subdirectories, that's the default for LaTeX compilation since 2ca3f80. Moreover this accounts for users setting a custom `out_dir` in their `.latexmkrc` and won't break even if the PDF exists in the same directory as the TeX source.