### PR TITLE
maint(init.vim): use `$XDG_CONFIG_HOME`

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -153,4 +153,4 @@ nnoremap <leader>h :call ToggleHiddenAll()<CR>
 " Here leader is ";".
 " So ":vs ;cfz" will expand into ":vs /home/<user>/.config/zsh/.zshrc"
 " if typed fast without the timeout.
-silent! source ~/.config/nvim/shortcuts.vim
+silent! source ${XDG_CONFIG_HOME:-$HOME/.config}/nvim/shortcuts.vim


### PR DESCRIPTION
- Substitute `~/.config` with `${XDG_CONFIG_HOME:-$HOME/.config}` to be consistent with rest of `init.vim`.