### PR TITLE
Revert "Fix UI rendering issues in neovim (#1455)"

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -62,8 +62,7 @@ colorscheme vim
 	endif
 	let g:airline_symbols.colnr = ' C:'
 	let g:airline_symbols.linenr = ' L:'
-	let g:airline_symbols.maxlinenr = ' '
-	let g:airline#extensions#whitespace#symbol = '!'
+	let g:airline_symbols.maxlinenr = '☰ '
 
 " Shortcutting split navigation, saving a keypress:
 	map <C-h> <C-w>h


### PR DESCRIPTION
The `☰` symbol was removed from airline due to a bug in NeoVim. We can have it back now that NeoVim 0.11 is out!

This reverts commit 8e2abf828a736f376f01ce14ae34d1b7fe9bfa8a, see #1455 for more context.