### PR TITLE
Disable termguicolors in init.vim

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -30,6 +30,7 @@ set noshowmode
 set noruler
 set laststatus=0
 set noshowcmd
+set notermguicolors
 colorscheme vim
 
 " Some basics:


### PR DESCRIPTION
The `colorscheme vim` command will set a colorscheme different from that of the default Vim colorscheme, this is because of Neovim's termguicolors. In order for the vim colorscheme to work properly the `bg` option needs to be light (which is already set) and the `termguicolors` option needs to be turned off.

This is the difference between termguicolors set and not set:

this is with termguicolors:
![image](https://github.com/user-attachments/assets/0df29e0f-42eb-4757-9474-b7d21233dd90)

and this is without termguicolors:
![image](https://github.com/user-attachments/assets/ddbf5ff0-3c44-409a-97dd-c0607f89b717)

