### PR TITLE
Improve system mute on lock

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -14,13 +14,12 @@ wmpid(){ # This function is needed if there are multiple instances of the window
 }
 
 lock(){
-    mpc pause
-    pauseallmpv
-    wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
-    kill -44 $(pidof dwmblocks)
-    slock
-    wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
-    kill -44 $(pidof dwmblocks)
+	was_muted="$(wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -o 'MUTED' && echo 1 || echo 0)"
+	mpc pause & pauseallmpv &
+	wpctl set-mute @DEFAULT_AUDIO_SINK@ 1 &
+	slock
+	[ "$was_muted" -eq 0 ] && wpctl set-mute @DEFAULT_AUDIO_SINK@ 0
+	pkill -RTMIN+10 "${STATUSBAR:-dwmblocks}"
 }
 
 case "$(printf "🔒 lock\n🚪 leave $WM\n♻️ renew $WM\n🐻 hibernate\n🔃 reboot\n🖥️shutdown\n💤 sleep\n📺 display off" | dmenu -i -p 'Action: ')" in


### PR DESCRIPTION
-Switch to explicit mute instead of toggle.
-Retain mute state from before locking after unlocking.