### PR TITLE
Remove redundant pref in larbs.js

### DIFF
--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -2,7 +2,6 @@
 // desired. Any of these settings can be overridden by the user.
 
 // Disable the Twitter/R*ddit/Faceberg ads in the URL bar:
-user_pref("browser.urlbar.quicksuggest.enabled", false);
 user_pref("browser.urlbar.suggest.topsites", false); // [FF78+]
 
 // Do not suggest web history in the URL bar:


### PR DESCRIPTION
Arkenfox sets browser.urlbar.quicksuggest.enabled to false (0802).