### PR TITLE
Add vim nav bluetooth module to statusbar

### DIFF
--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -3,12 +3,12 @@
 # now for the case statment 
 case $BLOCK_BUTTON in
     1) setsid -f "$TERMINAL" -e bluetui ;;
-    2) toggle_bt; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
+    2) bluetoothctl power toggle; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
     3) notify-send " Bluetooth module" "Shows bluetooth status:
-BT: bluetooth enabled
-BT: bluetooth disabled
-- left click to open bluetui
-- middle click to toggle bluetooth on/off" ;;
+🔵BT: Bluetooth enabled
+⚫BT: Bluetooth disabled
+- Left click to open bluetui
+- Middle click to toggle bluetooth on/off" ;;
     6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
@@ -20,8 +20,8 @@ esac
 
 # found old commit for sb-bluetooth nd in there reccomended use timeout
 
-if timeout 0.1s bluetoothctl show | grep -q "Powered: yes"; then
-    echo "BT"
+if timeout 0.5s bluetoothctl show | grep -q "Powered: yes"; then
+    echo "🔵BT"
 else
-    echo "BT off"
+    echo "⚫BT"
 fi

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -2,3 +2,9 @@
 
 # Shows bluetooth status and helper actions.
 
+# need way to check if bt is on/off
+# will dep on bluetoothctl
+
+if bluetoothctl show | grep -q "Powered: yes"; then
+    echo "BT"
+fi

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 # Shows bluetooth status and helper actions.
+# Requires bluetoothctl and bluetui
 
 case $BLOCK_BUTTON in
 	1) setsid -f "$TERMINAL" -e bluetui ;;
-	2) bluetoothctl power "$(timeout 1s bluetoothctl show | grep -q "Powered: yes" && echo off || echo on)"
+	2) bluetoothctl power "$(timeout 1s bluetoothctl show | grep -q "Powered: yes" && echo off || echo on)" &&
 		pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}"
 		;;
 	3) notify-send "Bluetooth module" "Shows bluetooth status:

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Shows bluetooth status and helper actions.
+

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -1,10 +1,22 @@
 #!/bin/sh
 
+# now for the case statment 
+case $BLOCK_BUTTON in
+    1) setsid -f "$TERMINAL" -e bluetui ;;
+
+    6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
+esac
+
 # Shows bluetooth status and helper actions.
 
 # need way to check if bt is on/off
 # will dep on bluetoothctl
+# also gotta think of a good icon
 
-if bluetoothctl show | grep -q "Powered: yes"; then
+# found old commit for sb-bluetooth nd in there reccomended use timeout
+
+if timeout 0.1s bluetoothctl show | grep -q "Powered: yes"; then
     echo "BT"
+else
+    echo "BT off"
 fi

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -3,18 +3,20 @@
 # Shows bluetooth status and helper actions.
 
 case $BLOCK_BUTTON in
-    1) setsid -f "$TERMINAL" -e bluetui ;;
-    2) bluetoothctl power "$(timeout 1s bluetoothctl show | grep -q "Powered: yes" && echo off || echo on)"; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
-    3) notify-send " Bluetooth module" "Shows bluetooth status:
+	1) setsid -f "$TERMINAL" -e bluetui ;;
+	2) bluetoothctl power "$(timeout 1s bluetoothctl show | grep -q "Powered: yes" && echo off || echo on)"
+		pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}"
+		;;
+	3) notify-send "Bluetooth module" "Shows bluetooth status:
 🔵BT: Bluetooth enabled
 ⚫BT: Bluetooth disabled
 - Left click to open bluetui
 - Middle click to toggle bluetooth on/off" ;;
-    6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
+	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
 if timeout 0.5s bluetoothctl show | grep -q "Powered: yes"; then
-    echo "🔵BT"
+	echo "🔵BT"
 else
-    echo "⚫BT"
+	echo "⚫BT"
 fi

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-# now for the case statment 
+# Shows bluetooth status and helper actions.
+
 case $BLOCK_BUTTON in
     1) setsid -f "$TERMINAL" -e bluetui ;;
     2) bluetoothctl power toggle; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
@@ -11,14 +12,6 @@ case $BLOCK_BUTTON in
 - Middle click to toggle bluetooth on/off" ;;
     6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
-
-# Shows bluetooth status and helper actions.
-
-# need way to check if bt is on/off
-# will dep on bluetoothctl
-# also gotta think of a good icon
-
-# found old commit for sb-bluetooth nd in there reccomended use timeout
 
 if timeout 0.5s bluetoothctl show | grep -q "Powered: yes"; then
     echo "🔵BT"

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -4,7 +4,7 @@
 
 case $BLOCK_BUTTON in
     1) setsid -f "$TERMINAL" -e bluetui ;;
-    2) bluetoothctl power toggle; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
+    2) bluetoothctl power "$(timeout 1s bluetoothctl show | grep -q "Powered: yes" && echo off || echo on)"; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
     3) notify-send " Bluetooth module" "Shows bluetooth status:
 🔵BT: Bluetooth enabled
 ⚫BT: Bluetooth disabled

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -3,7 +3,7 @@
 # now for the case statment 
 case $BLOCK_BUTTON in
     1) setsid -f "$TERMINAL" -e bluetui ;;
-
+    2) toggle_bt; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
     6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -4,6 +4,11 @@
 case $BLOCK_BUTTON in
     1) setsid -f "$TERMINAL" -e bluetui ;;
     2) toggle_bt; pkill -RTMIN+20 "${STATUSBAR:-dwmblocks}" ;;
+    3) notify-send " Bluetooth module" "Shows bluetooth status:
+BT: bluetooth enabled
+BT: bluetooth disabled
+- left click to open bluetui
+- middle click to toggle bluetooth on/off" ;;
     6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 

--- a/.local/bin/statusbar/sb-bluetooth
+++ b/.local/bin/statusbar/sb-bluetooth
@@ -16,8 +16,4 @@ case $BLOCK_BUTTON in
 	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-if timeout 0.5s bluetoothctl show | grep -q "Powered: yes"; then
-	echo "🔵BT"
-else
-	echo "⚫BT"
-fi
+timeout 0.5s bluetoothctl show | grep -q "Powered: yes" && echo "🔵BT" || echo "⚫BT"


### PR DESCRIPTION
This status bar module makes Bluetooth painless.

Middle click to toggle bluetooth on/off
Left click to open bluetui.

The bluetui supports **vim** bindings and looks great.


Main Deps:
- bluetui
- bluetoothctl

<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/c589825b-aa9d-4744-bb59-f63edd8928fb" />


Will need a block entry.

```{"", "sb-bluetooth", 5, 20},```