### PR TITLE
Simplified linkhandler

### DIFF
--- a/.local/bin/linkhandler
+++ b/.local/bin/linkhandler
@@ -6,21 +6,19 @@
 # if a music file or pdf, it will download,
 # otherwise it opens link in browser.
 
-if [ -z "$1" ]; then
-	url="$(xclip -o)"
-else
-	url="$1"
-fi
+url="${1:-$(xclip -o)}"
+
+tmpfile="/tmp/$(printf %s "$url" | sed "s/.*\///;s/%20/ /g")"
 
 case "$url" in
 	*mkv|*webm|*mp4|*youtube.com/watch*|*youtube.com/playlist*|*youtube.com/shorts*|*youtu.be*|*hooktube.com*|*bitchute.com*|*videos.lukesmith.xyz*|*odysee.com*)
 		setsid -f mpv -quiet "$url" >/dev/null 2>&1 ;;
 	*png|*jpg|*jpe|*jpeg|*gif|*webp)
-		curl -sL "$url" > "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")" && nsxiv -a "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
+		curl -sL -o "$tmpfile" "$url" && nsxiv -a "$tmpfile" >/dev/null 2>&1 & ;;
 	*pdf|*cbz|*cbr)
-		curl -sL "$url" > "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")" && zathura "/tmp/$(echo "$url" | sed "s/.*\///;s/%20/ /g")"  >/dev/null 2>&1 & ;;
+		curl -sL -o "$tmpfile" "$url" && zathura "$tmpfile" >/dev/null 2>&1 & ;;
 	*mp3|*flac|*opus|*mp3?source*)
-		qndl "$url" 'curl -LO'  >/dev/null 2>&1 ;;
+		qndl "$url" "curl -LO" >/dev/null 2>&1 ;;
 	*)
 		[ -f "$url" ] && setsid -f "$TERMINAL" -e "$EDITOR" "$url" >/dev/null 2>&1 || setsid -f "$BROWSER" "$url" >/dev/null 2>&1
 esac


### PR DESCRIPTION
Instead of an if block shell parameter expansion can be done. Define the /tmp file so sed only has to run once.