### PR TITLE
Silence pauseallmpv output in sysact

### DIFF
--- a/.local/bin/sysact
+++ b/.local/bin/sysact
@@ -15,7 +15,7 @@ wmpid(){ # This function is needed if there are multiple instances of the window
 
 lock(){
 	was_muted="$(wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -o 'MUTED' && echo 1 || echo 0)"
-	mpc pause & pauseallmpv &
+	mpc pause & pauseallmpv >/dev/null 2>&1 &
 	wpctl set-mute @DEFAULT_AUDIO_SINK@ 1 &
 	slock
 	[ "$was_muted" -eq 0 ] && wpctl set-mute @DEFAULT_AUDIO_SINK@ 0


### PR DESCRIPTION
Without this if pauseallmpv exits non-0 (usually old sockets in /tmp/mpvSockets) the screen freezes and I have to kill xorg from another tty.