### PR TITLE
Fix compiler for markdown

### DIFF
--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -24,11 +24,11 @@ case "${ext}" in
     h) sudo make install ;;
     java) javac -d classes "${file}" && java -cp classes "${base}" ;;
     m) octave "${file}" ;;
-    md) [ -x "$(command -v lowdown)" ] && \
-	    lowdown --parse-no-intraemph "${file}" -Tms | groff -mpdfmark -ms -kept -T pdf > "${base}.pdf" || \
-	    [ -x "$(command -v groffdown)" ] && \
-	    groffdown -i "${file}" | groff -T pdf > "${base}.pdf" || \
-	    pandoc -t ms --highlight-style="kate" -s -o "${base}.pdf" "${file}" ;;
+    md) { command -v lowdown &&
+	    lowdown --parse-no-intraemph "${file}" -Tms | groff -ms -kept -T pdf >"${base}.pdf" ;} ||
+	{ command -v groffdown &&
+	    groffdown -i "${file}" | groff -T pdf >"${base}.pdf" ;} ||
+	pandoc -t ms --highlight-style="kate" -s -o "${base}.pdf" "${file}" ;;
     org) emacs "${file}" --batch -u "${USER}" -f org-latex-export-to-pdf ;;
     py) python "${file}" ;;
     rink) rink -f "${file}" ;;

--- a/.local/bin/compiler
+++ b/.local/bin/compiler
@@ -28,7 +28,7 @@ case "${ext}" in
 	    lowdown --parse-no-intraemph "${file}" -Tms | groff -ms -kept -T pdf >"${base}.pdf" ;} ||
 	{ command -v groffdown &&
 	    groffdown -i "${file}" | groff -T pdf >"${base}.pdf" ;} ||
-	pandoc -t ms --highlight-style="kate" -s -o "${base}.pdf" "${file}" ;;
+	pandoc -t ms --highlight-style="kate" -s "${file}" | groff -ms -kept -T pdf >"${base}.pdf" ;;
     org) emacs "${file}" --batch -u "${USER}" -f org-latex-export-to-pdf ;;
     py) python "${file}" ;;
     rink) rink -f "${file}" ;;


### PR DESCRIPTION
groff removed pdfmark (https://lwn.net/Articles/1060786/) and it doesn't seem available as a package on Artix or from the AUR. Running test on command seems superfluous, and without the braces if lowdown is installed and exits with success, it will skip the command check for groffdown and try to run it and output nothing to the pdf file, deleting it