### PR TITLE
Clean up larb.js

### DIFF
--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -22,8 +22,6 @@ user_pref("dom.security.https_only_mode", false);
 // Keep cookies until expiration or user deletion:
 user_pref("network.cookie.lifetimePolicy", 0);
 
-user_pref("dom.webnotifications.serviceworker.enabled", false);
-
 // Disable push notifications:
 user_pref("dom.push.enabled", false);
 

--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -34,8 +34,5 @@ user_pref("privacy.clearOnShutdown.cookies", false);
 // Enable custom userChrome.js:
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 
-// Disable Firefox sync and its menu entries
-user_pref("identity.fxaccounts.enabled", false);
-
 // Fix the issue where right mouse button instantly clicks
 user_pref("ui.context_menus.after_mouseup", true);

--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -25,9 +25,6 @@ user_pref("network.cookie.lifetimePolicy", 0);
 // Disable push notifications:
 user_pref("dom.push.enabled", false);
 
-// Disable the pocket antifeature:
-user_pref("extensions.pocket.enabled", false);
-
 // Don't autodelete cookies on shutdown:
 user_pref("privacy.clearOnShutdown.cookies", false);
 

--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -36,9 +36,6 @@ user_pref("privacy.clearOnShutdown.cookies", false);
 // Enable custom userChrome.js:
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 
-// This could otherwise cause some issues on bank logins and other annoying sites:
-user_pref("network.http.referer.XOriginPolicy", 0);
-
 // Disable Firefox sync and its menu entries
 user_pref("identity.fxaccounts.enabled", false);
 


### PR DESCRIPTION
Half of these are for Librewolf's defaults. If you want larbs.js to be for any version of Firefox, I'll create a new PR. Summary (forgive the Reddit spacing):

- dom.webnotifications.serviceworker.enabled

This pref was removed in Firefox 117.
https://bugzilla.mozilla.org/show_bug.cgi?id=1842457
https://hg.mozilla.org/mozilla-central/rev/561997b14367

- extensions.pocket.enabled

The pocket antifeature does not exist in Librewolf.
https://www.librewolf.net/docs/features/#annoyances

- network.http.referer.XOriginPolicy

Default is 0.

- identity.fxaccounts.enabled

Default is false in Librewolf.
https://codeberg.org/librewolf/settings/src/branch/master/librewolf.cfg#L522