### PR TITLE
Clean up larbs.js

### DIFF
--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -34,9 +34,6 @@ user_pref("privacy.clearOnShutdown.cookies", false);
 // Enable custom userChrome.js:
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 
-// This could otherwise cause some issues on bank logins and other annoying sites:
-user_pref("network.http.referer.XOriginPolicy", 0);
-
 // Disable Firefox sync and its menu entries
 user_pref("identity.fxaccounts.enabled", false);
 

--- a/.config/firefox/larbs.js
+++ b/.config/firefox/larbs.js
@@ -22,8 +22,6 @@ user_pref("dom.security.https_only_mode", false);
 // Keep cookies until expiration or user deletion:
 user_pref("network.cookie.lifetimePolicy", 0);
 
-user_pref("dom.webnotifications.serviceworker.enabled", false);
-
 // Disable push notifications:
 user_pref("dom.push.enabled", false);
 


### PR DESCRIPTION
Summary (forgive the R*ddit spacing):

- dom.webnotifications.serviceworker.enabled

Removed in Firefox 117:
https://bugzilla.mozilla.org/show_bug.cgi?id=1842457
https://hg.mozilla.org/mozilla-central/rev/561997b14367

- network.http.referer.XOriginPolicy

Default is 0:
https://searchfox.org/firefox-release/source/modules/libpref/init/StaticPrefList.yaml#14770