### PR TITLE
sb-news replace awk with parameter expansion

### DIFF
--- a/.local/bin/statusbar/sb-news
+++ b/.local/bin/statusbar/sb-news
@@ -14,4 +14,8 @@ case $BLOCK_BUTTON in
 	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
- cat /tmp/newsupdate 2>/dev/null || echo "$(newsboat -x print-unread | awk '{ if($1>0) print "📰" $1}')$(cat "${XDG_CONFIG_HOME:-$HOME/.config}"/newsboat/.update 2>/dev/null)"
+cat /tmp/newsupdate 2>/dev/null || {
+	unread="$(newsboat -x print-unread)"
+	unread="${unread%% *}"
+	[ "$unread" -gt 0 ] && printf "📰%s\n" "$unread"
+}


### PR DESCRIPTION
Also cleaned up the formatting.

I cannot figure out what the purpose of running cat ~/.config/newsboat/.update was, neither newsboat nor newsup crated it while updating feeds.