### PR TITLE
sb-memory replace awk with parameter expansion

### DIFF
--- a/.local/bin/statusbar/sb-memory
+++ b/.local/bin/statusbar/sb-memory
@@ -9,4 +9,9 @@ case $BLOCK_BUTTON in
 	6) setsid -f "$TERMINAL" -e "$EDITOR" "$0" ;;
 esac
 
-free --mebi | sed -n '2{p;q}' | awk '{printf ("🧠%2.2fGiB/%2.2fGiB\n", ( $3 / 1024), ($2 / 1024))}'
+free="$(free --mebi)"
+free="${free#*Mem:}"
+
+set -- $free
+
+printf "🧠%2.2fGiB/%2.2fGiB\n" "$(( $2 * 100 / 1024 ))e-2" "$(( $1 * 100 / 1024 ))e-2"


### PR DESCRIPTION
time results:
```
sh -c 'for x in $(seq 1000); do sb-memory >/dev/null; done'  3.00s user 5.72s system 133% cpu 6.530 total # awk 
sh -c 'for x in $(seq 1000); do sb-memory >/dev/null; done'  1.32s user 2.69s system 95% cpu 4.180 total # parameter expansion
```